### PR TITLE
Expose API routes under /api alias

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -29,7 +29,14 @@ def seed_roles() -> None:
         session.commit()
 
 
+# Nota: la aplicación web espera actualmente que los endpoints vivan bajo
+# ``/api`` mientras que la API estaba versionada en ``/api/v1``.  Esto
+# provocaba errores 404 al autenticarse porque las solicitudes llegaban a
+# ``/auth/login`` sin el prefijo de versión.  Para mantener compatibilidad con
+# el frontend sin romper los clientes que ya usan ``/api/v1`` incluimos el
+# router dos veces, otorgando un alias sin versión.
 app.include_router(api_router, prefix="/api/v1")
+app.include_router(api_router, prefix="/api")
 
 
 app.add_middleware(


### PR DESCRIPTION
## Summary
- add a versionless /api router prefix in addition to /api/v1 to match the frontend's expectations
- document the compatibility reason directly in the FastAPI application setup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5b7d79d908325931a78a4f21122d8