### PR TITLE
Align ORM models with database schema

### DIFF
--- a/app/api/v1/personas_routes.py
+++ b/app/api/v1/personas_routes.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter, Depends, HTTPException
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Path
 from sqlalchemy.orm import Session
+
 from app.api.deps import get_db
-from app.db.models import Persona, CIPersona, SexoEnum, date   # 👈 importa SexoEnum
+from app.db.models import CIPersona, Persona, SexoEnum
 from app.schemas.personas import PersonaCreate, PersonaOut
-from typing import List
-from fastapi import Path
+
+
 router = APIRouter()
 
 @router.post("/", response_model=PersonaOut)
@@ -29,9 +32,6 @@ def crear_persona(data: PersonaCreate, db: Session = Depends(get_db)):
         ))
     db.commit(); db.refresh(p)
     return p
-from typing import List
-from app.schemas.personas import PersonaOut
-
 @router.get("/{persona_id}", response_model=PersonaOut)
 def obtener_persona(persona_id: int = Path(..., gt=0), db: Session = Depends(get_db)):
     p = db.get(Persona, persona_id)
@@ -54,9 +54,10 @@ def actualizar_persona(persona_id: int, data: PersonaUpdate, db: Session = Depen
     for field, value in data.model_dump(exclude_unset=True).items():
         if value is not None:
             if field == "sexo":
-                from app.db.models import SexoEnum
                 setattr(p, field, SexoEnum(value))  # valida 'M','F','X'
             else:
                 setattr(p, field, value)
-    db.add(p); db.commit(); db.refresh(p)
+    db.add(p)
+    db.commit()
+    db.refresh(p)
     return p

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -31,11 +31,20 @@ class EstadoUsuarioEnum(str, Enum):
     INACTIVO = "INACTIVO"
 
 
+class SexoEnum(str, Enum):
+    """Sex designation used by :class:`Persona` records."""
+
+    MASCULINO = "M"
+    FEMENINO = "F"
+    OTRO = "X"
+
+
 class Rol(Base):
     __tablename__ = "roles"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     nombre: Mapped[str] = mapped_column(String(30), unique=True, nullable=False)
+    codigo: Mapped[str] = mapped_column(String(20), unique=True, nullable=False)
 
     usuarios: Mapped[list["Usuario"]] = relationship("Usuario", back_populates="rol")
 
@@ -46,7 +55,9 @@ class Persona(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     nombres: Mapped[str] = mapped_column(String(120), nullable=False)
     apellidos: Mapped[str] = mapped_column(String(120), nullable=False)
-    sexo: Mapped[str] = mapped_column(String(1), nullable=False)
+    sexo: Mapped[SexoEnum] = mapped_column(
+        SAEnum(SexoEnum, name="sexo_enum", native_enum=False), nullable=False
+    )
     fecha_nacimiento: Mapped[date] = mapped_column(Date, nullable=False)
     celular: Mapped[str | None] = mapped_column(String(20))
     direccion: Mapped[str | None] = mapped_column(String(255))
@@ -108,7 +119,7 @@ class Estudiante(Base):
     persona_id: Mapped[int] = mapped_column(
         ForeignKey("personas.id", ondelete="CASCADE"), nullable=False
     )
-    codigo_est: Mapped[str] = mapped_column(String(50), nullable=False, unique=True)
+    codigo_est: Mapped[str | None] = mapped_column(String(30), unique=True)
 
     __table_args__ = (UniqueConstraint("codigo_est", name="uq_est_codigo"),)
 
@@ -176,7 +187,7 @@ class Nivel(Base):
     __tablename__ = "niveles"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    nombre: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    nombre: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     etiqueta: Mapped[str] = mapped_column(String(20), nullable=False)
 
 
@@ -187,8 +198,9 @@ class Curso(Base):
     nivel_id: Mapped[int] = mapped_column(
         ForeignKey("niveles.id", ondelete="CASCADE"), nullable=False
     )
-    nombre: Mapped[str] = mapped_column(String(100), nullable=False)
+    nombre: Mapped[str] = mapped_column(String(60), nullable=False)
     etiqueta: Mapped[str] = mapped_column(String(20), nullable=False)
+    grado: Mapped[int | None] = mapped_column(SmallInteger)
 
     __table_args__ = (
         UniqueConstraint("nivel_id", "nombre", name="uq_cursos_nivel_nombre"),
@@ -203,9 +215,11 @@ class Paralelo(Base):
         ForeignKey("cursos.id", ondelete="CASCADE"), nullable=False
     )
     etiqueta: Mapped[str] = mapped_column(String(10), nullable=False)
+    nombre: Mapped[str] = mapped_column(String(10), nullable=False, unique=True)
 
     __table_args__ = (
         UniqueConstraint("curso_id", "etiqueta", name="uq_paralelo"),
+        UniqueConstraint("nombre", name="uq_paralelo_nombre"),
     )
 
 
@@ -254,6 +268,7 @@ class Docente(Base):
         ForeignKey("personas.id", ondelete="CASCADE"), nullable=False, unique=True
     )
     titulo: Mapped[str | None] = mapped_column(String(120))
+    profesion: Mapped[str | None] = mapped_column(String(120))
 
 
 class AsignacionDocente(Base):

--- a/app/schemas/docentes.py
+++ b/app/schemas/docentes.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 class DocenteBase(BaseModel):
     persona_id: int = Field(gt=0)
     titulo: str | None = Field(default=None, max_length=120)
+    profesion: str | None = Field(default=None, max_length=120)
 
 
 class DocenteCreate(DocenteBase):


### PR DESCRIPTION
## Summary
- align several SQLAlchemy models with the existing MySQL schema (roles, personas, estudiantes, niveles, cursos, paralelos, docentes)
- expose profesion in the docente schema and clean up personas routes imports to use the shared SexoEnum helper

## Testing
- python -m compileall app/db/models.py app/api/v1/personas_routes.py app/schemas/docentes.py

------
https://chatgpt.com/codex/tasks/task_e_68d5fb1613348325a2f235175110b8c9