### PR TITLE
Fix login failures caused by bcrypt and persona enum serialization

### DIFF
--- a/app/schemas/personas.py
+++ b/app/schemas/personas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
 from datetime import date
 from typing import Literal
 
@@ -19,4 +20,5 @@ class PersonaCreate(PersonaBase):
 
 class PersonaOut(PersonaBase):
     id: int
-    class Config: from_attributes = True
+
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn==0.30.6
 SQLAlchemy==2.0.35
 PyMySQL==1.1.1
 python-dotenv==1.0.1
+bcrypt==4.1.2
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0
 pydantic==2.8.2


### PR DESCRIPTION
## Summary
- ensure persona response models serialize SexoEnum values correctly for API responses
- pin bcrypt dependency to a version compatible with passlib to avoid runtime import errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5fd94d2288325b0dbbdc4520ae47f