### PR TITLE
Handle sexo enum short codes

### DIFF
--- a/app/api/v1/personas_routes.py
+++ b/app/api/v1/personas_routes.py
@@ -15,7 +15,7 @@ def crear_persona(data: PersonaCreate, db: Session = Depends(get_db)):
     p = Persona(
         nombres=data.nombres,
         apellidos=data.apellidos,
-        sexo=SexoEnum(data.sexo),            # 👈 convierte "F" -> SexoEnum.F
+        sexo=SexoEnum(data.sexo),            # acepta "F" o "FEMENINO"
         fecha_nacimiento=data.fecha_nacimiento,
         celular=data.celular,
         direccion=data.direccion,
@@ -43,7 +43,7 @@ class PersonaUpdate(PersonaCreate):
     # todos opcionales para PATCH-like
     nombres: str | None = None
     apellidos: str | None = None
-    sexo: str | None = None
+    sexo: SexoEnum | None = None
     fecha_nacimiento: date | None = None
 
 @router.put("/{persona_id}", response_model=PersonaOut)
@@ -54,7 +54,7 @@ def actualizar_persona(persona_id: int, data: PersonaUpdate, db: Session = Depen
     for field, value in data.model_dump(exclude_unset=True).items():
         if value is not None:
             if field == "sexo":
-                setattr(p, field, SexoEnum(value))  # valida 'M','F','X'
+                setattr(p, field, SexoEnum(value))  # valida códigos o nombres
             else:
                 setattr(p, field, value)
     db.add(p)

--- a/app/schemas/personas.py
+++ b/app/schemas/personas.py
@@ -1,17 +1,23 @@
-from pydantic import BaseModel, Field
-from pydantic.config import ConfigDict
 from datetime import date
-from typing import Literal
 
-Sexo = Literal["M","F","X"]
+from pydantic import BaseModel, Field, field_serializer
+from pydantic.config import ConfigDict
+
+from app.db.models import SexoEnum
 
 class PersonaBase(BaseModel):
     nombres: str = Field(min_length=1, max_length=120)
     apellidos: str = Field(min_length=1, max_length=120)
-    sexo: Sexo
+    sexo: SexoEnum
     fecha_nacimiento: date
     celular: str | None = None
     direccion: str | None = None
+
+    @field_serializer("sexo", when_used="json")
+    def serialize_sexo(self, sexo: SexoEnum) -> str:
+        if isinstance(sexo, SexoEnum):
+            return sexo.short_code
+        return str(sexo)
 
 class PersonaCreate(PersonaBase):
     ci_numero: str | None = None
@@ -21,4 +27,4 @@ class PersonaCreate(PersonaBase):
 class PersonaOut(PersonaBase):
     id: int
 
-    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- normalise `SexoEnum` values so both verbose labels and short codes are accepted
- update persona schemas to serialise enums using the historical `M`/`F`/`X` codes
- adjust persona routes to rely on the new enum behaviour during create and update flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5ff7935ac8325b6795f8ba9e8c6e8