### PR TITLE
feat: add remaining endpoints

### DIFF
--- a/app/api/v1/docentes.py
+++ b/app/api/v1/docentes.py
@@ -1,0 +1,74 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_role
+from app.db.models import Docente, Persona
+from app.schemas.docentes import DocenteCreate, DocenteOut, DocenteUpdate
+
+router = APIRouter(tags=["docentes"])
+
+
+@router.get("/", response_model=List[DocenteOut])
+def listar_docentes(
+    db: Session = Depends(get_db),
+    persona_id: int | None = Query(None, ge=1),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    q = db.query(Docente)
+    if persona_id is not None:
+        q = q.filter(Docente.persona_id == persona_id)
+    return q.order_by(Docente.id).offset(offset).limit(limit).all()
+
+
+@router.get("/{docente_id}", response_model=DocenteOut)
+def obtener_docente(docente_id: int, db: Session = Depends(get_db)):
+    docente = db.get(Docente, docente_id)
+    if not docente:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Docente no encontrado")
+    return docente
+
+
+@router.post(
+    "/",
+    response_model=DocenteOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def crear_docente(payload: DocenteCreate, db: Session = Depends(get_db)):
+    persona = db.get(Persona, payload.persona_id)
+    if not persona:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Persona no encontrada")
+
+    existe = db.query(Docente).filter(Docente.persona_id == payload.persona_id).first()
+    if existe:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Docente ya existe para la persona")
+
+    docente = Docente(**payload.model_dump())
+    db.add(docente)
+    db.commit()
+    db.refresh(docente)
+    return docente
+
+
+@router.patch(
+    "/{docente_id}",
+    response_model=DocenteOut,
+    dependencies=[Depends(require_role("admin"))],
+)
+def actualizar_docente(docente_id: int, payload: DocenteUpdate, db: Session = Depends(get_db)):
+    docente = db.get(Docente, docente_id)
+    if not docente:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Docente no encontrado")
+
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(docente, key, value)
+
+    db.add(docente)
+    db.commit()
+    db.refresh(docente)
+    return docente

--- a/app/api/v1/gestiones.py
+++ b/app/api/v1/gestiones.py
@@ -1,0 +1,88 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_role
+from app.db.models import Gestion
+from app.schemas.gestiones import GestionCreate, GestionOut, GestionUpdate
+
+router = APIRouter(tags=["gestiones"])
+
+
+@router.get("/", response_model=List[GestionOut])
+def listar_gestiones(
+    db: Session = Depends(get_db),
+    solo_activas: bool = Query(False),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    q = db.query(Gestion).order_by(Gestion.fecha_inicio.desc())
+    if solo_activas:
+        q = q.filter(Gestion.activo == 1)
+    return q.offset(offset).limit(limit).all()
+
+
+@router.get("/{gestion_id}", response_model=GestionOut)
+def obtener_gestion(gestion_id: int, db: Session = Depends(get_db)):
+    gestion = db.get(Gestion, gestion_id)
+    if not gestion:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Gestión no encontrada")
+    return gestion
+
+
+@router.post(
+    "/",
+    response_model=GestionOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def crear_gestion(payload: GestionCreate, db: Session = Depends(get_db)):
+    if payload.fecha_fin < payload.fecha_inicio:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="fecha_fin debe ser mayor o igual a fecha_inicio")
+
+    existente = db.query(Gestion).filter(Gestion.nombre == payload.nombre).first()
+    if existente:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Gestión ya existe")
+
+    gestion = Gestion(**payload.model_dump())
+    db.add(gestion)
+    db.commit()
+    db.refresh(gestion)
+    return gestion
+
+
+@router.patch(
+    "/{gestion_id}",
+    response_model=GestionOut,
+    dependencies=[Depends(require_role("admin"))],
+)
+def actualizar_gestion(gestion_id: int, payload: GestionUpdate, db: Session = Depends(get_db)):
+    gestion = db.get(Gestion, gestion_id)
+    if not gestion:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Gestión no encontrada")
+
+    data = payload.model_dump(exclude_unset=True)
+    if "fecha_inicio" in data or "fecha_fin" in data:
+        nueva_inicio = data.get("fecha_inicio", gestion.fecha_inicio)
+        nueva_fin = data.get("fecha_fin", gestion.fecha_fin)
+        if nueva_fin < nueva_inicio:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="fecha_fin debe ser mayor o igual a fecha_inicio")
+
+    if "nombre" in data:
+        duplicado = (
+            db.query(Gestion)
+            .filter(Gestion.nombre == data["nombre"], Gestion.id != gestion_id)
+            .first()
+        )
+        if duplicado:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nombre ya en uso")
+
+    for key, value in data.items():
+        setattr(gestion, key, value)
+
+    db.add(gestion)
+    db.commit()
+    db.refresh(gestion)
+    return gestion

--- a/app/api/v1/niveles.py
+++ b/app/api/v1/niveles.py
@@ -1,0 +1,81 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_role
+from app.db.models import Nivel
+from app.schemas.niveles import NivelCreate, NivelOut, NivelUpdate
+
+router = APIRouter(tags=["niveles"])
+
+
+@router.get("/", response_model=List[NivelOut])
+def listar_niveles(
+    db: Session = Depends(get_db),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    return (
+        db.query(Nivel)
+        .order_by(Nivel.id)
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+
+@router.get("/{nivel_id}", response_model=NivelOut)
+def obtener_nivel(nivel_id: int, db: Session = Depends(get_db)):
+    nivel = db.get(Nivel, nivel_id)
+    if not nivel:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Nivel no encontrado")
+    return nivel
+
+
+@router.post(
+    "/",
+    response_model=NivelOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def crear_nivel(payload: NivelCreate, db: Session = Depends(get_db)):
+    existente = db.query(Nivel).filter(Nivel.nombre == payload.nombre).first()
+    if existente:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nivel ya existe")
+
+    nivel = Nivel(**payload.model_dump())
+    db.add(nivel)
+    db.commit()
+    db.refresh(nivel)
+    return nivel
+
+
+@router.patch(
+    "/{nivel_id}",
+    response_model=NivelOut,
+    dependencies=[Depends(require_role("admin"))],
+)
+def actualizar_nivel(nivel_id: int, payload: NivelUpdate, db: Session = Depends(get_db)):
+    nivel = db.get(Nivel, nivel_id)
+    if not nivel:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Nivel no encontrado")
+
+    data = payload.model_dump(exclude_unset=True)
+    if "nombre" in data:
+        duplicado = (
+            db.query(Nivel)
+            .filter(Nivel.nombre == data["nombre"], Nivel.id != nivel_id)
+            .first()
+        )
+        if duplicado:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nombre ya en uso")
+
+    for key, value in data.items():
+        setattr(nivel, key, value)
+
+    db.add(nivel)
+    db.commit()
+    db.refresh(nivel)
+    return nivel

--- a/app/api/v1/planes.py
+++ b/app/api/v1/planes.py
@@ -1,0 +1,81 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_role
+from app.db.models import Curso, Materia, PlanCursoMateria
+from app.schemas.planes import (
+    PlanCursoMateriaCreate,
+    PlanCursoMateriaOut,
+    PlanCursoMateriaUpdate,
+)
+
+router = APIRouter(tags=["planes"])
+
+
+@router.get("/", response_model=List[PlanCursoMateriaOut])
+def listar_planes(
+    db: Session = Depends(get_db),
+    curso_id: int | None = Query(None, ge=1),
+    materia_id: int | None = Query(None, ge=1),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    q = db.query(PlanCursoMateria)
+    if curso_id is not None:
+        q = q.filter(PlanCursoMateria.curso_id == curso_id)
+    if materia_id is not None:
+        q = q.filter(PlanCursoMateria.materia_id == materia_id)
+    return q.order_by(PlanCursoMateria.id).offset(offset).limit(limit).all()
+
+
+@router.post(
+    "/",
+    response_model=PlanCursoMateriaOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def crear_plan(payload: PlanCursoMateriaCreate, db: Session = Depends(get_db)):
+    if not db.get(Curso, payload.curso_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Curso no encontrado")
+    if not db.get(Materia, payload.materia_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Materia no encontrada")
+
+    existente = (
+        db.query(PlanCursoMateria)
+        .filter(
+            PlanCursoMateria.curso_id == payload.curso_id,
+            PlanCursoMateria.materia_id == payload.materia_id,
+        )
+        .first()
+    )
+    if existente:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Plan ya existe")
+
+    plan = PlanCursoMateria(**payload.model_dump())
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan
+
+
+@router.patch(
+    "/{plan_id}",
+    response_model=PlanCursoMateriaOut,
+    dependencies=[Depends(require_role("admin"))],
+)
+def actualizar_plan(plan_id: int, payload: PlanCursoMateriaUpdate, db: Session = Depends(get_db)):
+    plan = db.get(PlanCursoMateria, plan_id)
+    if not plan:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan no encontrado")
+
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(plan, key, value)
+
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+    return plan

--- a/app/api/v1/roles.py
+++ b/app/api/v1/roles.py
@@ -1,0 +1,85 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_role
+from app.db.models import Rol
+from app.schemas.roles import RolCreate, RolOut
+
+router = APIRouter(tags=["roles"])
+
+
+@router.get("/", response_model=List[RolOut])
+def listar_roles(
+    db: Session = Depends(get_db),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    return (
+        db.query(Rol)
+        .order_by(Rol.id)
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+
+
+@router.get("/{rol_id}", response_model=RolOut)
+def obtener_rol(rol_id: int, db: Session = Depends(get_db)):
+    rol = db.get(Rol, rol_id)
+    if not rol:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
+    return rol
+
+
+@router.post(
+    "/",
+    response_model=RolOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def crear_rol(payload: RolCreate, db: Session = Depends(get_db)):
+    existente = (
+        db.query(Rol)
+        .filter((Rol.nombre == payload.nombre) | (Rol.codigo == payload.codigo))
+        .first()
+    )
+    if existente:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rol ya existe")
+
+    rol = Rol(nombre=payload.nombre, codigo=payload.codigo)
+    db.add(rol)
+    db.commit()
+    db.refresh(rol)
+    return rol
+
+
+@router.put(
+    "/{rol_id}",
+    response_model=RolOut,
+    dependencies=[Depends(require_role("admin"))],
+)
+def actualizar_rol(rol_id: int, payload: RolCreate, db: Session = Depends(get_db)):
+    rol = db.get(Rol, rol_id)
+    if not rol:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
+
+    duplicado = (
+        db.query(Rol)
+        .filter(
+            ((Rol.nombre == payload.nombre) | (Rol.codigo == payload.codigo))
+            & (Rol.id != rol_id)
+        )
+        .first()
+    )
+    if duplicado:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nombre o código ya en uso")
+
+    rol.nombre = payload.nombre
+    rol.codigo = payload.codigo
+    db.add(rol)
+    db.commit()
+    db.refresh(rol)
+    return rol

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -8,15 +8,21 @@ from . import (
     asistencia,
     asignaciones,
     auth,
+    docentes,
     cursos,
     evaluaciones,
     estudiantes,
     frontend,
+    gestiones,
     matriculas,
+    niveles,
     notas,
     paralelos,
     personas,
+    planes,
     reportes,
+    roles,
+    usuarios,
 )
 
 api_router = APIRouter()
@@ -27,6 +33,12 @@ api_router.include_router(notas.router,        prefix="/notas",        tags=["no
 api_router.include_router(evaluaciones.router, prefix="/evaluaciones", tags=["evaluaciones"])
 api_router.include_router(cursos.router,       prefix="/cursos",       tags=["cursos"])
 api_router.include_router(paralelos.router,    prefix="/paralelos",    tags=["paralelos"])
+api_router.include_router(niveles.router,      prefix="/niveles",      tags=["niveles"])
+api_router.include_router(gestiones.router,    prefix="/gestiones",    tags=["gestiones"])
+api_router.include_router(docentes.router,     prefix="/docentes",     tags=["docentes"])
+api_router.include_router(usuarios.router,     prefix="/usuarios",     tags=["usuarios"])
+api_router.include_router(roles.router,        prefix="/roles",        tags=["roles"])
+api_router.include_router(planes.router,       prefix="/planes",       tags=["planes"])
 
 # 🔐 usa el alias explícito (evita choques con app.schemas.materias)
 api_router.include_router(materias_router)

--- a/app/api/v1/usuarios.py
+++ b/app/api/v1/usuarios.py
@@ -1,0 +1,89 @@
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session, selectinload
+
+from app.api.deps import get_db, get_current_user
+from app.api.deps_extra import require_role
+from app.core.security import hash_password
+from app.db.models import EstadoUsuarioEnum, Persona, Usuario
+from app.schemas.usuarios import UsuarioCreate, UsuarioOut, UsuarioUpdate
+
+router = APIRouter(tags=["usuarios"])
+
+
+@router.get("/", response_model=List[UsuarioOut], dependencies=[Depends(get_current_user)])
+def listar_usuarios(
+    db: Session = Depends(get_db),
+    limit: int = Query(100, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    rol_id: int | None = Query(None, ge=1),
+    estado: EstadoUsuarioEnum | None = Query(None),
+):
+    q = db.query(Usuario).options(selectinload(Usuario.persona))
+    if rol_id is not None:
+        q = q.filter(Usuario.rol_id == rol_id)
+    if estado is not None:
+        q = q.filter(Usuario.estado == estado)
+    usuarios = q.order_by(Usuario.id).offset(offset).limit(limit).all()
+    return usuarios
+
+
+@router.get("/{usuario_id}", response_model=UsuarioOut, dependencies=[Depends(get_current_user)])
+def obtener_usuario(usuario_id: int, db: Session = Depends(get_db)):
+    usuario = (
+        db.query(Usuario)
+        .options(selectinload(Usuario.persona))
+        .filter(Usuario.id == usuario_id)
+        .first()
+    )
+    if not usuario:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuario no encontrado")
+    return usuario
+
+
+@router.post(
+    "/",
+    response_model=UsuarioOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(require_role("admin"))],
+)
+def crear_usuario(payload: UsuarioCreate, db: Session = Depends(get_db)):
+    if db.query(Usuario).filter(Usuario.username == payload.username).first():
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Usuario ya existe")
+
+    persona = db.get(Persona, payload.persona_id)
+    if not persona:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Persona no encontrada")
+
+    usuario = Usuario(
+        persona_id=payload.persona_id,
+        username=payload.username,
+        password_hash=hash_password(payload.password),
+        rol_id=payload.rol_id,
+        estado=EstadoUsuarioEnum.ACTIVO,
+    )
+    db.add(usuario)
+    db.commit()
+    db.refresh(usuario)
+    return UsuarioOut.model_validate(usuario, from_attributes=True)
+
+
+@router.patch(
+    "/{usuario_id}",
+    response_model=UsuarioOut,
+    dependencies=[Depends(require_role("admin"))],
+)
+def actualizar_usuario(usuario_id: int, payload: UsuarioUpdate, db: Session = Depends(get_db)):
+    usuario = db.get(Usuario, usuario_id)
+    if not usuario:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuario no encontrado")
+
+    data = payload.model_dump(exclude_unset=True)
+    for key, value in data.items():
+        setattr(usuario, key, value)
+
+    db.add(usuario)
+    db.commit()
+    db.refresh(usuario)
+    return UsuarioOut.model_validate(usuario, from_attributes=True)

--- a/app/schemas/docentes.py
+++ b/app/schemas/docentes.py
@@ -11,6 +11,11 @@ class DocenteCreate(DocenteBase):
     pass
 
 
+class DocenteUpdate(BaseModel):
+    titulo: str | None = Field(default=None, max_length=120)
+    profesion: str | None = Field(default=None, max_length=120)
+
+
 class DocenteOut(DocenteBase):
     id: int
 

--- a/app/schemas/gestiones.py
+++ b/app/schemas/gestiones.py
@@ -1,0 +1,27 @@
+from datetime import date
+from pydantic import BaseModel, Field
+
+
+class GestionBase(BaseModel):
+    nombre: str = Field(min_length=1, max_length=20)
+    fecha_inicio: date
+    fecha_fin: date
+    activo: int = Field(default=1, ge=0, le=1)
+
+
+class GestionCreate(GestionBase):
+    pass
+
+
+class GestionUpdate(BaseModel):
+    nombre: str | None = Field(default=None, min_length=1, max_length=20)
+    fecha_inicio: date | None = None
+    fecha_fin: date | None = None
+    activo: int | None = Field(default=None, ge=0, le=1)
+
+
+class GestionOut(GestionBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/app/schemas/niveles.py
+++ b/app/schemas/niveles.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field
+
+
+class NivelBase(BaseModel):
+    nombre: str = Field(min_length=1, max_length=50)
+    etiqueta: str = Field(min_length=1, max_length=20)
+
+
+class NivelCreate(NivelBase):
+    pass
+
+
+class NivelUpdate(BaseModel):
+    nombre: str | None = Field(default=None, min_length=1, max_length=50)
+    etiqueta: str | None = Field(default=None, min_length=1, max_length=20)
+
+
+class NivelOut(NivelBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/app/schemas/planes.py
+++ b/app/schemas/planes.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel, Field
+
+
+class PlanCursoMateriaBase(BaseModel):
+    curso_id: int = Field(gt=0)
+    materia_id: int = Field(gt=0)
+    horas_sem: int | None = Field(default=None, ge=0)
+
+
+class PlanCursoMateriaCreate(PlanCursoMateriaBase):
+    pass
+
+
+class PlanCursoMateriaUpdate(BaseModel):
+    horas_sem: int | None = Field(default=None, ge=0)
+
+
+class PlanCursoMateriaOut(PlanCursoMateriaBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/app/schemas/roles.py
+++ b/app/schemas/roles.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, Field
+
+
+class RolBase(BaseModel):
+    nombre: str = Field(min_length=1, max_length=30)
+    codigo: str = Field(min_length=1, max_length=20)
+
+
+class RolCreate(RolBase):
+    pass
+
+
+class RolOut(RolBase):
+    id: int
+
+    class Config:
+        from_attributes = True

--- a/app/schemas/usuarios.py
+++ b/app/schemas/usuarios.py
@@ -14,6 +14,11 @@ class Token(BaseModel):
     token_type: str = "bearer"
 
 
+class UsuarioUpdate(BaseModel):
+    rol_id: int | None = None
+    estado: EstadoUsuarioEnum | None = None
+
+
 class UsuarioOut(BaseModel):
     id: int
     username: str


### PR DESCRIPTION
## Summary
- add CRUD endpoints for roles, usuarios, gestiones, niveles, planes y docentes
- create supporting Pydantic schemas for the new resources
- register the routers so the new endpoints are exposed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d603d843c48325905b62fb4c5bebd6