### PR TITLE
feat: add view permissions and audit logging

### DIFF
--- a/alembic/versions/ce370f07d10f_add_vistas_and_audit_logs.py
+++ b/alembic/versions/ce370f07d10f_add_vistas_and_audit_logs.py
@@ -1,0 +1,61 @@
+"""add vistas and audit logs
+
+Revision ID: ce370f07d10f
+Revises: b1b20f6bbce8
+Create Date: 2025-09-29 23:36:00.739920
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ce370f07d10f'
+down_revision: Union[str, Sequence[str], None] = 'b1b20f6bbce8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'vistas',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('nombre', sa.String(length=60), nullable=False),
+        sa.Column('codigo', sa.String(length=60), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('codigo'),
+    )
+
+    op.create_table(
+        'audit_logs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('actor_id', sa.Integer(), nullable=True),
+        sa.Column('accion', sa.String(length=60), nullable=False),
+        sa.Column('entidad', sa.String(length=60), nullable=False),
+        sa.Column('entidad_id', sa.String(length=60), nullable=True),
+        sa.Column('ip_origen', sa.String(length=45), nullable=True),
+        sa.Column('user_agent', sa.String(length=255), nullable=True),
+        sa.Column('creado_en', sa.DateTime(), server_default=sa.text('CURRENT_TIMESTAMP'), nullable=False),
+        sa.ForeignKeyConstraint(['actor_id'], ['usuarios.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+    op.create_table(
+        'rol_vistas',
+        sa.Column('rol_id', sa.Integer(), nullable=False),
+        sa.Column('vista_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['rol_id'], ['roles.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['vista_id'], ['vistas.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('rol_id', 'vista_id'),
+        sa.UniqueConstraint('rol_id', 'vista_id', name='uq_rol_vista'),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('rol_vistas')
+    op.drop_table('audit_logs')
+    op.drop_table('vistas')

--- a/app/api/deps_extra.py
+++ b/app/api/deps_extra.py
@@ -2,27 +2,59 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 from fastapi import Depends, HTTPException, status
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from app.api.deps import get_current_user, get_db
 from app.db.models import Rol, Usuario
 
 
-def require_role(*codes: Iterable[str] | str):
-    if len(codes) == 1 and not isinstance(codes[0], str):
-        allowed = {str(code).upper() for code in codes[0]}
-    else:
-        allowed = {str(code).upper() for code in codes}
+def _load_rol(user: Usuario, db: Session) -> Rol | None:
+    if not getattr(user, "rol_id", None):
+        return None
+    return (
+        db.query(Rol)
+        .options(selectinload(Rol.vistas))
+        .filter(Rol.id == user.rol_id)
+        .first()
+    )
+
+
+def _normalise(values: Sequence[str] | Iterable[str]) -> set[str]:
+    return {str(value).upper() for value in values}
+
+
+def require_view(code: str):
+    required = str(code).upper()
 
     def dependency(
         user: Usuario = Depends(get_current_user),
         db: Session = Depends(get_db),
     ) -> Usuario:
-        rol_id = getattr(user, "rol_id", None)
-        rol = db.get(Rol, rol_id) if rol_id else None
+        rol = _load_rol(user, db)
+        if rol and any(v.codigo.upper() == required for v in rol.vistas):
+            return user
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Permisos insuficientes",
+        )
+
+    return dependency
+
+
+def require_role(*codes: Iterable[str] | str):
+    if len(codes) == 1 and not isinstance(codes[0], str):
+        allowed = _normalise(codes[0])
+    else:
+        allowed = _normalise(codes)
+
+    def dependency(
+        user: Usuario = Depends(get_current_user),
+        db: Session = Depends(get_db),
+    ) -> Usuario:
+        rol = _load_rol(user, db)
         nombre = rol.nombre.upper() if rol and rol.nombre else None
         if nombre in allowed:
             return user
@@ -30,5 +62,30 @@ def require_role(*codes: Iterable[str] | str):
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Permisos insuficientes",
         )
+
+    return dependency
+
+
+def require_role_and_view(roles: Iterable[str], view_code: str):
+    allowed_roles = _normalise(roles)
+    required_view = str(view_code).upper()
+
+    def dependency(
+        user: Usuario = Depends(get_current_user),
+        db: Session = Depends(get_db),
+    ) -> Usuario:
+        rol = _load_rol(user, db)
+        nombre = rol.nombre.upper() if rol and rol.nombre else None
+        if nombre not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes",
+            )
+        if not any(v.codigo.upper() == required_view for v in rol.vistas):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes",
+            )
+        return user
 
     return dependency

--- a/app/api/v1/asignaciones.py
+++ b/app/api/v1/asignaciones.py
@@ -1,14 +1,17 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-from app.api.deps import get_db, get_current_user
-from app.db.models import AsignacionDocente, Docente, Materia, Curso, Paralelo, Gestion
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_view
+from app.db.models import AsignacionDocente, Docente, Gestion, Materia, Curso, Paralelo, Usuario
 
 router = APIRouter(tags=["asignaciones"])
 
-@router.post("/", dependencies=[Depends(get_current_user)])
+@router.post("/")
 def crear_asignacion(
     data: dict,  # o tu esquema
     db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("ASIGNACIONES")),
 ):
     # data: {gestion: "2025", docente_id, materia_id, curso_id, paralelo_id}
     g = db.query(Gestion).filter(Gestion.nombre == data["gestion"]).first()
@@ -39,7 +42,7 @@ def crear_asignacion(
     db.add(a); db.commit(); db.refresh(a)
     return a
 
-@router.get("/", dependencies=[Depends(get_current_user)])
+@router.get("/")
 def listar_asignaciones(
     gestion: str | None = Query(default=None),
     docente_id: int | None = Query(default=None),
@@ -47,6 +50,7 @@ def listar_asignaciones(
     paralelo_id: int | None = Query(default=None),
     materia_id: int | None = Query(default=None),
     db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("ASIGNACIONES")),
 ):
     q = db.query(AsignacionDocente)
     if gestion is not None:

--- a/app/api/v1/auditoria.py
+++ b/app/api/v1/auditoria.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_role_and_view
+from app.db.models import AuditLog, Usuario
+from app.schemas.audit import AuditLogPage
+
+router = APIRouter(tags=["auditoria"])
+
+
+@router.get("/", response_model=AuditLogPage)
+def listar_auditoria(
+    db: Session = Depends(get_db),
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=200),
+    actor_id: int | None = Query(None, ge=1),
+    accion: str | None = Query(None, min_length=1, max_length=60),
+    entidad: str | None = Query(None, min_length=1, max_length=60),
+    _: Usuario = Depends(require_role_and_view({"admin"}, "AUDITORIA")),
+) -> AuditLogPage:
+    q = db.query(AuditLog)
+    if actor_id is not None:
+        q = q.filter(AuditLog.actor_id == actor_id)
+    if accion is not None:
+        q = q.filter(AuditLog.accion.ilike(f"%{accion}%"))
+    if entidad is not None:
+        q = q.filter(AuditLog.entidad.ilike(f"%{entidad}%"))
+
+    total = q.count()
+    rows = (
+        q.order_by(AuditLog.creado_en.desc())
+        .offset((page - 1) * size)
+        .limit(size)
+        .all()
+    )
+
+    return AuditLogPage(total=total, page=page, size=size, items=rows)

--- a/app/api/v1/cursos.py
+++ b/app/api/v1/cursos.py
@@ -2,22 +2,36 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 from app.api.deps import get_db
-from app.db.models import Curso, Paralelo
-from app.api.deps_extra import require_role  # usa el helper de arriba
+from app.api.deps_extra import require_role_and_view, require_view
+from app.db.models import Curso, Paralelo, Usuario
 
 router = APIRouter(tags=["cursos"])
 
 @router.get("/")
-def listar(offset:int=0, limit:int=50, db:Session=Depends(get_db)):
+def listar(
+    offset:int=0,
+    limit:int=50,
+    db:Session=Depends(get_db),
+    _: Usuario = Depends(require_view("CURSOS")),
+):
     return db.query(Curso).offset(offset).limit(limit).all()
 
-@router.post("/", dependencies=[Depends(require_role("admin"))])
-def crear_curso(curso_in: dict, db: Session = Depends(get_db)):
+@router.post("/")
+def crear_curso(
+    curso_in: dict,
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_role_and_view({"admin"}, "CURSOS")),
+):
     c = Curso(**curso_in)
     db.add(c); db.commit(); db.refresh(c)
     return c
 
-@router.post("/{curso_id}/paralelos", dependencies=[Depends(require_role("admin"))])
-def crear_paralelo(curso_id:int, data:dict, db:Session=Depends(get_db)):
+@router.post("/{curso_id}/paralelos")
+def crear_paralelo(
+    curso_id:int,
+    data:dict,
+    db:Session=Depends(get_db),
+    _: Usuario = Depends(require_role_and_view({"admin"}, "CURSOS")),
+):
     if not db.get(Curso, curso_id): raise HTTPException(404, "Curso no encontrado")
     p = Paralelo(curso_id=curso_id, **data); db.add(p); db.commit(); db.refresh(p); return p

--- a/app/api/v1/matriculas.py
+++ b/app/api/v1/matriculas.py
@@ -1,10 +1,10 @@
 from fastapi import APIRouter, Depends, HTTPException
-from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy import select
 
-from app.api.deps import get_db, get_current_user
-from app.db.models import Matricula, AsignacionDocente, Estudiante
+from app.api.deps import get_db
+from app.api.deps_extra import require_view
+from app.db.models import Matricula, AsignacionDocente, Estudiante, Usuario
 from app.schemas.matriculas import MatriculaCreate, MatriculaRead
 
 router = APIRouter(tags=["matriculas"])
@@ -13,7 +13,7 @@ router = APIRouter(tags=["matriculas"])
 def create_matricula(
     data: MatriculaCreate,
     db: Session = Depends(get_db),
-    user=Depends(get_current_user),
+    _: Usuario = Depends(require_view("MATRICULAS")),
 ):
     # valida asignación / estudiante
     if not db.get(AsignacionDocente, data.asignacion_id):
@@ -42,7 +42,7 @@ def list_matriculas(
     asignacion_id: int | None = None,
     estudiante_id: int | None = None,
     db: Session = Depends(get_db),
-    user=Depends(get_current_user),
+    _: Usuario = Depends(require_view("MATRICULAS")),
 ):
     stmt = select(Matricula)
     if asignacion_id is not None:

--- a/app/api/v1/paralelos.py
+++ b/app/api/v1/paralelos.py
@@ -1,16 +1,24 @@
 from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
-from app.api.deps import get_db, get_current_user
-from app.db.models import Paralelo
+from app.api.deps import get_db
+from app.api.deps_extra import require_view
+from app.db.models import Paralelo, Usuario
 
 router = APIRouter()
 
 @router.get("/")
-def listar_paralelos(db: Session = Depends(get_db), _=Depends(get_current_user)):
+def listar_paralelos(
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("PARALELOS")),
+):
     return db.query(Paralelo).order_by(Paralelo.id.asc()).all()
 
 @router.post("/")
-def crear_paralelo(data: dict, db: Session = Depends(get_db), _=Depends(get_current_user)):
+def crear_paralelo(
+    data: dict,
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("PARALELOS")),
+):
     p = Paralelo(**data)
     db.add(p); db.commit(); db.refresh(p)
     return p

--- a/app/api/v1/reportes.py
+++ b/app/api/v1/reportes.py
@@ -3,13 +3,18 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, get_current_user
-from app.db.models import Nota, Evaluacion
+from app.api.deps import get_db
+from app.api.deps_extra import require_view
+from app.db.models import Nota, Evaluacion, Usuario
 
 router = APIRouter(tags=["reportes"])
 
 @router.get("/estudiante/{est_id}/notas")
-def notas_estudiante(est_id: int, db: Session = Depends(get_db), _=Depends(get_current_user)):
+def notas_estudiante(
+    est_id: int,
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("REPORTES")),
+):
     q = (
         db.query(
             Evaluacion.titulo,
@@ -32,7 +37,11 @@ def notas_estudiante(est_id: int, db: Session = Depends(get_db), _=Depends(get_c
     ]
 
 @router.get("/curso/{asig_id}/promedios")
-def promedios_curso(asig_id: int, db: Session = Depends(get_db), _=Depends(get_current_user)):
+def promedios_curso(
+    asig_id: int,
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("REPORTES")),
+):
     q = (
         db.query(
             Nota.estudiante_id,

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -22,6 +22,7 @@ from . import (
     reportes,
     roles,
     usuarios,
+    auditoria,
 )
 
 api_router = APIRouter()
@@ -47,3 +48,4 @@ api_router.include_router(asignaciones.router, prefix="/asignaciones", tags=["as
 api_router.include_router(matriculas.router,   prefix="/matriculas",   tags=["matriculas"])
 api_router.include_router(reportes.router,     prefix="/reportes",     tags=["reportes"])
 api_router.include_router(alertas.router, prefix="/alertas", tags=["alertas"])
+api_router.include_router(auditoria.router,    prefix="/auditoria",   tags=["auditoria"])

--- a/app/api/v1/usuarios.py
+++ b/app/api/v1/usuarios.py
@@ -1,26 +1,34 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session, selectinload
 
-from app.api.deps import get_db, get_current_user
-from app.api.deps_extra import require_role
+from app.api.deps import get_db
+from app.api.deps_extra import require_role_and_view, require_view
 from app.core.security import hash_password
-from app.db.models import EstadoUsuarioEnum, Persona, Usuario
+from app.core.audit import registrar_auditoria
+from app.db.models import EstadoUsuarioEnum, Persona, Rol, Usuario
 from app.schemas.usuarios import UsuarioCreate, UsuarioOut, UsuarioUpdate
 
 router = APIRouter(tags=["usuarios"])
 
 
-@router.get("/", response_model=List[UsuarioOut], dependencies=[Depends(get_current_user)])
+@router.get("/", response_model=List[UsuarioOut])
 def listar_usuarios(
     db: Session = Depends(get_db),
     limit: int = Query(100, ge=1, le=200),
     offset: int = Query(0, ge=0),
     rol_id: int | None = Query(None, ge=1),
     estado: EstadoUsuarioEnum | None = Query(None),
+    _: Usuario = Depends(require_view("USUARIOS")),
 ):
-    q = db.query(Usuario).options(selectinload(Usuario.persona))
+    q = (
+        db.query(Usuario)
+        .options(
+            selectinload(Usuario.persona),
+            selectinload(Usuario.rol).selectinload(Rol.vistas),
+        )
+    )
     if rol_id is not None:
         q = q.filter(Usuario.rol_id == rol_id)
     if estado is not None:
@@ -29,11 +37,18 @@ def listar_usuarios(
     return usuarios
 
 
-@router.get("/{usuario_id}", response_model=UsuarioOut, dependencies=[Depends(get_current_user)])
-def obtener_usuario(usuario_id: int, db: Session = Depends(get_db)):
+@router.get("/{usuario_id}", response_model=UsuarioOut)
+def obtener_usuario(
+    usuario_id: int,
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("USUARIOS")),
+):
     usuario = (
         db.query(Usuario)
-        .options(selectinload(Usuario.persona))
+        .options(
+            selectinload(Usuario.persona),
+            selectinload(Usuario.rol).selectinload(Rol.vistas),
+        )
         .filter(Usuario.id == usuario_id)
         .first()
     )
@@ -46,15 +61,23 @@ def obtener_usuario(usuario_id: int, db: Session = Depends(get_db)):
     "/",
     response_model=UsuarioOut,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(require_role("admin"))],
 )
-def crear_usuario(payload: UsuarioCreate, db: Session = Depends(get_db)):
+def crear_usuario(
+    payload: UsuarioCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: Usuario = Depends(require_role_and_view({"admin"}, "USUARIOS")),
+):
     if db.query(Usuario).filter(Usuario.username == payload.username).first():
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Usuario ya existe")
 
     persona = db.get(Persona, payload.persona_id)
     if not persona:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Persona no encontrada")
+
+    rol = db.get(Rol, payload.rol_id)
+    if not rol:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
 
     usuario = Usuario(
         persona_id=payload.persona_id,
@@ -66,18 +89,44 @@ def crear_usuario(payload: UsuarioCreate, db: Session = Depends(get_db)):
     db.add(usuario)
     db.commit()
     db.refresh(usuario)
+    registrar_auditoria(
+        db,
+        actor_id=current_user.id,
+        accion="CREAR",
+        entidad="USUARIO",
+        entidad_id=usuario.id,
+        request=request,
+    )
+    usuario = (
+        db.query(Usuario)
+        .options(
+            selectinload(Usuario.persona),
+            selectinload(Usuario.rol).selectinload(Rol.vistas),
+        )
+        .filter(Usuario.id == usuario.id)
+        .first()
+    )
     return UsuarioOut.model_validate(usuario, from_attributes=True)
 
 
 @router.patch(
     "/{usuario_id}",
     response_model=UsuarioOut,
-    dependencies=[Depends(require_role("admin"))],
 )
-def actualizar_usuario(usuario_id: int, payload: UsuarioUpdate, db: Session = Depends(get_db)):
+def actualizar_usuario(
+    usuario_id: int,
+    payload: UsuarioUpdate,
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: Usuario = Depends(require_role_and_view({"admin"}, "USUARIOS")),
+):
     usuario = db.get(Usuario, usuario_id)
     if not usuario:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuario no encontrado")
+
+    rol = db.get(Rol, payload.rol_id)
+    if not rol:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
 
     data = payload.model_dump(exclude_unset=True)
     for key, value in data.items():
@@ -86,4 +135,21 @@ def actualizar_usuario(usuario_id: int, payload: UsuarioUpdate, db: Session = De
     db.add(usuario)
     db.commit()
     db.refresh(usuario)
+    registrar_auditoria(
+        db,
+        actor_id=current_user.id,
+        accion="ACTUALIZAR",
+        entidad="USUARIO",
+        entidad_id=usuario.id,
+        request=request,
+    )
+    usuario = (
+        db.query(Usuario)
+        .options(
+            selectinload(Usuario.persona),
+            selectinload(Usuario.rol).selectinload(Rol.vistas),
+        )
+        .filter(Usuario.id == usuario.id)
+        .first()
+    )
     return UsuarioOut.model_validate(usuario, from_attributes=True)

--- a/app/core/audit.py
+++ b/app/core/audit.py
@@ -1,0 +1,60 @@
+"""Utilities for persisting audit logs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import Request
+from sqlalchemy.orm import Session
+
+from app.db.models import AuditLog
+
+
+def registrar_auditoria(
+    db: Session,
+    *,
+    actor_id: int | None,
+    accion: str,
+    entidad: str,
+    entidad_id: Any | None,
+    request: Request | None = None,
+) -> AuditLog:
+    """Persist an :class:`AuditLog` entry immediately.
+
+    Parameters
+    ----------
+    db:
+        Active SQLAlchemy session.
+    actor_id:
+        Identifier of the user performing the action (``None`` for anonymous).
+    accion:
+        Short verb describing the action (``CREAR``, ``ACTUALIZAR`` ...).
+    entidad:
+        Name of the affected entity (``USUARIO``, ``ROL`` ...).
+    entidad_id:
+        Identifier of the affected entity. Stored as a string to accommodate
+        composite identifiers.
+    request:
+        Optional request object used to extract IP and user agent metadata.
+    """
+
+    ip_origen = None
+    user_agent = None
+    if request is not None:
+        client = request.client
+        if client:
+            ip_origen = client.host
+        user_agent = request.headers.get("user-agent")
+
+    log = AuditLog(
+        actor_id=actor_id,
+        accion=accion,
+        entidad=entidad,
+        entidad_id=str(entidad_id) if entidad_id is not None else None,
+        ip_origen=ip_origen,
+        user_agent=user_agent,
+    )
+    db.add(log)
+    db.commit()
+    db.refresh(log)
+    return log

--- a/app/schemas/audit.py
+++ b/app/schemas/audit.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+
+class AuditLogOut(BaseModel):
+    id: int
+    actor_id: int | None = None
+    accion: str
+    entidad: str
+    entidad_id: str | None = None
+    ip_origen: str | None = None
+    user_agent: str | None = None
+    creado_en: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class AuditLogPage(BaseModel):
+    total: int = Field(ge=0)
+    page: int = Field(ge=1)
+    size: int = Field(ge=1)
+    items: list[AuditLogOut]

--- a/app/schemas/roles.py
+++ b/app/schemas/roles.py
@@ -1,17 +1,31 @@
 from pydantic import BaseModel, Field
 
 
+class VistaOut(BaseModel):
+    id: int
+    nombre: str
+    codigo: str
+
+    class Config:
+        from_attributes = True
+
+
 class RolBase(BaseModel):
     nombre: str = Field(min_length=1, max_length=30)
     codigo: str = Field(min_length=1, max_length=20)
 
 
 class RolCreate(RolBase):
-    pass
+    vista_ids: list[int] = Field(default_factory=list)
+
+
+class RolUpdate(RolBase):
+    vista_ids: list[int] | None = None
 
 
 class RolOut(RolBase):
     id: int
+    vistas: list[VistaOut] = Field(default_factory=list)
 
     class Config:
         from_attributes = True

--- a/app/schemas/usuarios.py
+++ b/app/schemas/usuarios.py
@@ -2,12 +2,13 @@ from pydantic import BaseModel, Field
 
 from app.db.models import EstadoUsuarioEnum
 from app.schemas.personas import PersonaOut
+from app.schemas.roles import RolOut
 
 class UsuarioCreate(BaseModel):
     persona_id: int
     username: str = Field(min_length=3, max_length=50)
     password: str = Field(min_length=6)
-    rol_id: int | None = None
+    rol_id: int = Field(gt=0)
 
 class Token(BaseModel):
     access_token: str
@@ -15,7 +16,7 @@ class Token(BaseModel):
 
 
 class UsuarioUpdate(BaseModel):
-    rol_id: int | None = None
+    rol_id: int = Field(gt=0)
     estado: EstadoUsuarioEnum | None = None
 
 
@@ -26,6 +27,7 @@ class UsuarioOut(BaseModel):
     rol_id: int | None = None
     estado: EstadoUsuarioEnum
     persona: PersonaOut | None = None
+    rol: RolOut | None = None
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add Vista and AuditLog models with migrations and helper utilities for auditing actions
- update role and user endpoints to manage view assignments, enforce permissions, and record audit entries
- secure protected API routes with view-based dependencies and expose an admin-only audit log listing endpoint

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68db15fb00a88325bc6add6525f6bc13