### PR TITLE
Add vistas listing endpoint

### DIFF
--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -19,6 +19,7 @@ from . import (
     paralelos,
     personas,
     planes,
+    vistas,
     reportes,
     roles,
     usuarios,
@@ -39,6 +40,7 @@ api_router.include_router(docentes.router,     prefix="/docentes",     tags=["do
 api_router.include_router(usuarios.router,     prefix="/usuarios",     tags=["usuarios"])
 api_router.include_router(roles.router,        prefix="/roles",        tags=["roles"])
 api_router.include_router(planes.router,       prefix="/planes",       tags=["planes"])
+api_router.include_router(vistas.router,       prefix="/vistas",       tags=["vistas"])
 
 # 🔐 usa el alias explícito (evita choques con app.schemas.materias)
 api_router.include_router(materias_router)

--- a/app/api/v1/vistas.py
+++ b/app/api/v1/vistas.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.api.deps_extra import require_view
+from app.db.models import Usuario, Vista
+from app.schemas.roles import VistaOut
+
+router = APIRouter(tags=["vistas"])
+
+
+@router.get("/", response_model=List[VistaOut])
+def listar_vistas(
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("ROLES")),
+):
+    return db.query(Vista).order_by(Vista.nombre).all()


### PR DESCRIPTION
## Summary
- add a dedicated router to list the available vistas to the frontend
- expose the vistas routes from the main API router so they can be consumed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db25a24790832592843189b892f9a5