### PR TITLE
Fix role permission checks to use codes

### DIFF
--- a/app/api/deps_extra.py
+++ b/app/api/deps_extra.py
@@ -55,8 +55,9 @@ def require_role(*codes: Iterable[str] | str):
         db: Session = Depends(get_db),
     ) -> Usuario:
         rol = _load_rol(user, db)
+        codigo = rol.codigo.upper() if rol and rol.codigo else None
         nombre = rol.nombre.upper() if rol and rol.nombre else None
-        if nombre in allowed:
+        if codigo in allowed or nombre in allowed:
             return user
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -75,8 +76,9 @@ def require_role_and_view(roles: Iterable[str], view_code: str):
         db: Session = Depends(get_db),
     ) -> Usuario:
         rol = _load_rol(user, db)
+        codigo = rol.codigo.upper() if rol and rol.codigo else None
         nombre = rol.nombre.upper() if rol and rol.nombre else None
-        if nombre not in allowed_roles:
+        if codigo not in allowed_roles and nombre not in allowed_roles:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Permisos insuficientes",


### PR DESCRIPTION
## Summary
- allow the role guard helpers to accept both role codes and names when validating
- prevent administrators whose role codes differ from their names from being blocked from role and view APIs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db4cc6a218832592eefd3508843a8d