### PR TITLE
Normalise role seeding to ignore case

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,13 +23,22 @@ def seed_roles() -> None:
     )
 
     with Session(engine) as session:
-        existing_names = {nombre for (nombre,) in session.execute(select(Rol.nombre))}
-        existing_codes = {codigo for (codigo,) in session.execute(select(Rol.codigo))}
+        existing_names = {
+            nombre.upper()
+            for (nombre,) in session.execute(select(Rol.nombre))
+            if nombre is not None
+        }
+        existing_codes = {
+            codigo.upper()
+            for (codigo,) in session.execute(select(Rol.codigo))
+            if codigo is not None
+        }
 
         missing_roles = [
             Rol(nombre=nombre, codigo=codigo)
             for nombre, codigo in desired_roles
-            if nombre not in existing_names and codigo not in existing_codes
+            if nombre.upper() not in existing_names
+            and codigo.upper() not in existing_codes
         ]
 
         if not missing_roles:


### PR DESCRIPTION
## Summary
- normalise the stored role names and codes to uppercase before collecting existing values during startup
- compare desired default roles using uppercase values so that seeding is case-insensitive and avoids duplicate inserts

## Testing
- PYTHONDONTWRITEBYTECODE=1 python - <<'PY'
import sys
import types
from fastapi import APIRouter

mock_router = types.ModuleType("app.api.v1.router")
mock_router.api_router = APIRouter()
sys.modules["app.api.v1.router"] = mock_router

mock_session = types.ModuleType("app.db.session")
mock_session.engine = None
mock_session.SessionLocal = None
sys.modules["app.db.session"] = mock_session

from sqlalchemy import create_engine, select
from sqlalchemy.orm import Session

import app.main as main
from app.db import models

engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
models.Base.metadata.create_all(engine)

main.engine = engine
mock_session.engine = engine

with Session(engine) as session:
    session.add(models.Rol(nombre="admin", codigo="admin"))
    session.commit()

main.seed_roles()

with Session(engine) as session:
    rows = session.execute(select(models.Rol.nombre, models.Rol.codigo)).all()

print(rows)
print(f"Total roles: {len(rows)}")
PY

------
https://chatgpt.com/codex/tasks/task_e_68db5643e7848325aa6f3487333be1b8