### PR TITLE
Pin bcrypt to 3.2.2 for passlib compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn==0.30.6
 SQLAlchemy==2.0.35
 PyMySQL==1.1.1
 python-dotenv==1.0.1
-bcrypt==4.1.2
+bcrypt==3.2.2
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0
 pydantic==2.8.2


### PR DESCRIPTION
## Summary
- pin bcrypt below 4.0 to keep compatibility with the current passlib release

## Testing
- `pip install -r requirements.txt` *(fails: proxy returns 403 when fetching bcrypt==3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_68db5c1ed4b0832598c89b4e99175b38