### PR TITLE
Seed vistas and superuser for RBAC

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,50 +1,194 @@
 """Application entry-point for Académico API."""
 
+from __future__ import annotations
+
+from datetime import date
+from typing import Final
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.routing import APIRoute
-from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy import func
+from sqlalchemy.orm import Session, selectinload
 
 from app.api.v1.router import api_router
-from app.db.models import Rol
+from app.core.security import hash_password
+from app.db.models import (
+    EstadoUsuarioEnum,
+    Persona,
+    Rol,
+    SexoEnum,
+    Usuario,
+    Vista,
+)
 from app.db.session import engine
 
 
 app = FastAPI(title="Académico API")
 
 
+DEFAULT_VISTAS: Final[dict[str, str]] = {
+    "USUARIOS": "Usuarios",
+    "ROLES": "Roles",
+    "VISTAS": "Vistas",
+    "PLANES": "Planes de estudio",
+    "GESTIONES": "Gestiones",
+    "NIVELES": "Niveles",
+    "DOCENTES": "Docentes",
+    "ASISTENCIAS": "Asistencias",
+    "CURSOS": "Cursos",
+    "ALERTAS": "Alertas",
+    "NOTAS": "Notas",
+    "MATERIAS": "Materias",
+    "REPORTES": "Reportes",
+    "PARALELOS": "Paralelos",
+    "ASIGNACIONES": "Asignaciones",
+    "MATRICULAS": "Matrículas",
+    "AUDITORIA": "Auditoría",
+}
+
+ROLE_TEMPLATES: Final[tuple[dict[str, object], ...]] = (
+    {
+        "nombre": "Administrador",
+        "codigo": "ADMIN",
+        "vista_codes": tuple(DEFAULT_VISTAS.keys()),
+    },
+    {
+        "nombre": "Docente",
+        "codigo": "DOC",
+        "vista_codes": (
+            "ASISTENCIAS",
+            "NOTAS",
+            "CURSOS",
+            "MATERIAS",
+            "ASIGNACIONES",
+            "REPORTES",
+            "ALERTAS",
+        ),
+    },
+    {
+        "nombre": "Padre de familia",
+        "codigo": "PAD",
+        "vista_codes": (
+            "ASISTENCIAS",
+            "NOTAS",
+            "REPORTES",
+            "ALERTAS",
+        ),
+    },
+)
+
+SUPERUSER_USERNAME: Final[str] = "root"
+SUPERUSER_PASSWORD: Final[str] = "CambiarAhora123!"
+SUPERUSER_NAMES: Final[str] = "Súper"
+SUPERUSER_LASTNAMES: Final[str] = "Administrador"
+SUPERUSER_BIRTHDATE: Final[date] = date(1980, 1, 1)
+
+
 @app.on_event("startup")
-def seed_roles() -> None:
-    """Ensure that the default roles exist in the database."""
-    desired_roles = (
-        ("ADMIN", "ADMIN"),
-        ("DOCENTE", "DOC"),
-    )
+def bootstrap_access_control() -> None:
+    """Synchronise vistas, roles and privileged users with the database."""
 
     with Session(engine) as session:
-        existing_names = {
-            nombre.upper()
-            for (nombre,) in session.execute(select(Rol.nombre))
-            if nombre is not None
-        }
-        existing_codes = {
-            codigo.upper()
-            for (codigo,) in session.execute(select(Rol.codigo))
-            if codigo is not None
+        vistas_by_code: dict[str, Vista] = {
+            vista.codigo.upper(): vista for vista in session.query(Vista).all()
         }
 
-        missing_roles = [
-            Rol(nombre=nombre, codigo=codigo)
-            for nombre, codigo in desired_roles
-            if nombre.upper() not in existing_names
-            and codigo.upper() not in existing_codes
-        ]
+        for code, name in DEFAULT_VISTAS.items():
+            vista = vistas_by_code.get(code)
+            if vista is None:
+                vista = Vista(nombre=name, codigo=code)
+                session.add(vista)
+                session.flush()
+                vistas_by_code[code] = vista
+            else:
+                updated = False
+                if vista.nombre != name:
+                    vista.nombre = name
+                    updated = True
+                if vista.codigo != code:
+                    vista.codigo = code
+                    updated = True
+                if updated:
+                    session.add(vista)
+                vistas_by_code[code] = vista
 
-        if not missing_roles:
-            return
+        session.flush()
 
-        session.add_all(missing_roles)
+        for template in ROLE_TEMPLATES:
+            codigo = template["codigo"]
+            vista_codes = tuple(template["vista_codes"])
+            vistas = [vistas_by_code[view_code] for view_code in vista_codes]
+
+            rol: Rol | None = (
+                session.query(Rol)
+                .options(selectinload(Rol.vistas))
+                .filter(func.upper(Rol.codigo) == codigo)
+                .first()
+            )
+            if rol is None:
+                rol = Rol(nombre=template["nombre"], codigo=codigo)
+                session.add(rol)
+                session.flush()
+            else:
+                rol.nombre = template["nombre"]
+                rol.codigo = codigo
+
+            rol.vistas = vistas
+            session.add(rol)
+
+        session.flush()
+
+        admin_role: Rol | None = (
+            session.query(Rol)
+            .filter(func.upper(Rol.codigo) == "ADMIN")
+            .first()
+        )
+
+        if admin_role is not None:
+            admin_user = (
+                session.query(Usuario)
+                .filter(func.lower(Usuario.username) == "admin")
+                .first()
+            )
+            if admin_user is not None and admin_user.rol_id != admin_role.id:
+                admin_user.rol = admin_role
+
+            superuser = (
+                session.query(Usuario)
+                .filter(func.lower(Usuario.username) == SUPERUSER_USERNAME.lower())
+                .first()
+            )
+            if superuser is None:
+                persona = (
+                    session.query(Persona)
+                    .filter(
+                        func.lower(Persona.nombres) == SUPERUSER_NAMES.lower(),
+                        func.lower(Persona.apellidos) == SUPERUSER_LASTNAMES.lower(),
+                    )
+                    .first()
+                )
+                if persona is None:
+                    persona = Persona(
+                        nombres=SUPERUSER_NAMES,
+                        apellidos=SUPERUSER_LASTNAMES,
+                        sexo=SexoEnum.MASCULINO,
+                        fecha_nacimiento=SUPERUSER_BIRTHDATE,
+                    )
+                    session.add(persona)
+                    session.flush()
+
+                superuser = Usuario(
+                    persona=persona,
+                    username=SUPERUSER_USERNAME,
+                    password_hash=hash_password(SUPERUSER_PASSWORD),
+                    rol=admin_role,
+                    estado=EstadoUsuarioEnum.ACTIVO,
+                )
+                session.add(superuser)
+            elif superuser.rol_id != admin_role.id:
+                superuser.rol = admin_role
+
         session.commit()
 
 


### PR DESCRIPTION
## Summary
- seed the catalog of vistas and synchronise it with default role templates during startup
- ensure the ADMIN, DOC and PAD roles exist with the expected permissions and keep their view assignments up to date
- provision an extra root superuser (and fix the legacy admin account) so there is always an account with access to every view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db76223e3483258e6c5e340aaf6a19