### PR TITLE
Disable role and view features temporarily

### DIFF
--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -50,16 +50,10 @@ def get_current_user(
 
 
 def require_roles(*roles_validos: str):
-    allowed = {role.upper() for role in roles_validos}
+    """Temporarily bypass role enforcement while roles are disabled."""
 
     def dependency(current_user: Usuario = Depends(get_current_user)) -> Usuario:
-        rol = current_user.rol.nombre.upper() if current_user.rol else None
-        if rol in allowed:
-            return current_user
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Permisos insuficientes",
-        )
+        return current_user
 
     return dependency
 

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -19,9 +19,7 @@ from . import (
     paralelos,
     personas,
     planes,
-    vistas,
     reportes,
-    roles,
     usuarios,
     auditoria,
 )
@@ -38,9 +36,7 @@ api_router.include_router(niveles.router,      prefix="/niveles",      tags=["ni
 api_router.include_router(gestiones.router,    prefix="/gestiones",    tags=["gestiones"])
 api_router.include_router(docentes.router,     prefix="/docentes",     tags=["docentes"])
 api_router.include_router(usuarios.router,     prefix="/usuarios",     tags=["usuarios"])
-api_router.include_router(roles.router,        prefix="/roles",        tags=["roles"])
 api_router.include_router(planes.router,       prefix="/planes",       tags=["planes"])
-api_router.include_router(vistas.router,       prefix="/vistas",       tags=["vistas"])
 
 # 🔐 usa el alias explícito (evita choques con app.schemas.materias)
 api_router.include_router(materias_router)

--- a/app/api/v1/usuarios.py
+++ b/app/api/v1/usuarios.py
@@ -26,7 +26,7 @@ def listar_usuarios(
         db.query(Usuario)
         .options(
             selectinload(Usuario.persona),
-            selectinload(Usuario.rol).selectinload(Rol.vistas),
+            selectinload(Usuario.rol),
         )
     )
     if rol_id is not None:
@@ -47,7 +47,7 @@ def obtener_usuario(
         db.query(Usuario)
         .options(
             selectinload(Usuario.persona),
-            selectinload(Usuario.rol).selectinload(Rol.vistas),
+            selectinload(Usuario.rol),
         )
         .filter(Usuario.id == usuario_id)
         .first()
@@ -75,9 +75,10 @@ def crear_usuario(
     if not persona:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Persona no encontrada")
 
-    rol = db.get(Rol, payload.rol_id)
-    if not rol:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
+    if payload.rol_id is not None:
+        rol = db.get(Rol, payload.rol_id)
+        if not rol:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
 
     usuario = Usuario(
         persona_id=payload.persona_id,
@@ -101,7 +102,7 @@ def crear_usuario(
         db.query(Usuario)
         .options(
             selectinload(Usuario.persona),
-            selectinload(Usuario.rol).selectinload(Rol.vistas),
+            selectinload(Usuario.rol),
         )
         .filter(Usuario.id == usuario.id)
         .first()
@@ -124,9 +125,10 @@ def actualizar_usuario(
     if not usuario:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuario no encontrado")
 
-    rol = db.get(Rol, payload.rol_id)
-    if not rol:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
+    if payload.rol_id is not None:
+        rol = db.get(Rol, payload.rol_id)
+        if not rol:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rol no encontrado")
 
     data = payload.model_dump(exclude_unset=True)
     for key, value in data.items():
@@ -147,7 +149,7 @@ def actualizar_usuario(
         db.query(Usuario)
         .options(
             selectinload(Usuario.persona),
-            selectinload(Usuario.rol).selectinload(Rol.vistas),
+            selectinload(Usuario.rol),
         )
         .filter(Usuario.id == usuario.id)
         .first()

--- a/app/schemas/usuarios.py
+++ b/app/schemas/usuarios.py
@@ -8,7 +8,7 @@ class UsuarioCreate(BaseModel):
     persona_id: int
     username: str = Field(min_length=3, max_length=50)
     password: str = Field(min_length=6)
-    rol_id: int = Field(gt=0)
+    rol_id: int | None = Field(default=None, ge=1)
 
 class Token(BaseModel):
     access_token: str
@@ -16,7 +16,7 @@ class Token(BaseModel):
 
 
 class UsuarioUpdate(BaseModel):
-    rol_id: int = Field(gt=0)
+    rol_id: int | None = Field(default=None, ge=1)
     estado: EstadoUsuarioEnum | None = None
 
 


### PR DESCRIPTION
## Summary
- remove the roles and vistas routers while RBAC is disabled
- bypass role/view dependency checks and relax user schemas to allow null roles
- simplify startup bootstrap to only ensure the default superuser exists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc85cd7f60832593699ceb6fb68c64