### PR TITLE
Fix ORM schema configuration for personas

### DIFF
--- a/app/schemas/docentes.py
+++ b/app/schemas/docentes.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DocenteBase(BaseModel):
@@ -19,5 +19,4 @@ class DocenteUpdate(BaseModel):
 class DocenteOut(DocenteBase):
     id: int
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/estudiantes.py
+++ b/app/schemas/estudiantes.py
@@ -1,5 +1,4 @@
-from pydantic import BaseModel, Field
-from pydantic import BaseModel, ConfigDict, Field  # 👈 añade esto
+from pydantic import BaseModel, ConfigDict, Field
 
 class EstudianteBase(BaseModel):
     persona_id: int = Field(..., gt=0)
@@ -8,10 +7,7 @@ class EstudianteBase(BaseModel):
 class EstudianteCreate(EstudianteBase):
     pass
 
-class EstudianteOut(BaseModel):
+class EstudianteOut(EstudianteBase):
     id: int
-    persona_id: int
-    codigo_est: str
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_schemas_serialization.py
+++ b/tests/test_schemas_serialization.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.db import models
+from app.schemas.docentes import DocenteOut
+from app.schemas.estudiantes import EstudianteOut
+
+
+def test_estudiante_out_accepts_orm_objects():
+    estudiante = models.Estudiante(id=1, persona_id=2, codigo_est="ABC123")
+
+    schema = EstudianteOut.model_validate(estudiante)
+
+    assert schema.id == 1
+    assert schema.persona_id == 2
+    assert schema.codigo_est == "ABC123"
+
+
+def test_docente_out_accepts_orm_objects():
+    docente = models.Docente(
+        id=7,
+        persona_id=3,
+        titulo="Lic.",
+        profesion="Educación",
+    )
+
+    schema = DocenteOut.model_validate(docente)
+
+    assert schema.id == 7
+    assert schema.persona_id == 3
+    assert schema.titulo == "Lic."
+    assert schema.profesion == "Educación"


### PR DESCRIPTION
## Summary
- update the estudiante and docente response schemas to configure `from_attributes` via `ConfigDict`
- add regression tests ensuring the schemas accept ORM instances without validation errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd6e1940488325a1a4386d1a9add0e