### PR TITLE
Add persona-aware creation flows for estudiantes and docentes

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -230,6 +230,8 @@ class Estudiante(Base):
     )
     codigo_est: Mapped[str | None] = mapped_column(String(30), unique=True)
 
+    persona: Mapped[Persona] = relationship("Persona")
+
     __table_args__ = (UniqueConstraint("codigo_est", name="uq_est_codigo"),)
 
 
@@ -378,6 +380,8 @@ class Docente(Base):
     )
     titulo: Mapped[str | None] = mapped_column(String(120))
     profesion: Mapped[str | None] = mapped_column(String(120))
+
+    persona: Mapped[Persona] = relationship("Persona")
 
 
 class AsignacionDocente(Base):

--- a/app/schemas/docentes.py
+++ b/app/schemas/docentes.py
@@ -1,14 +1,24 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.personas import PersonaCreate, PersonaOut
 
 
 class DocenteBase(BaseModel):
-    persona_id: int = Field(gt=0)
     titulo: str | None = Field(default=None, max_length=120)
     profesion: str | None = Field(default=None, max_length=120)
 
 
 class DocenteCreate(DocenteBase):
-    pass
+    persona_id: int | None = Field(default=None, gt=0)
+    persona: PersonaCreate | None = None
+
+    @model_validator(mode="after")
+    def check_persona_reference(self) -> "DocenteCreate":
+        persona_id_provided = self.persona_id is not None
+        persona_object_provided = self.persona is not None
+        if persona_id_provided == persona_object_provided:
+            raise ValueError("Debe proporcionar únicamente persona_id o persona")
+        return self
 
 
 class DocenteUpdate(BaseModel):
@@ -18,5 +28,7 @@ class DocenteUpdate(BaseModel):
 
 class DocenteOut(DocenteBase):
     id: int
+    persona_id: int
+    persona: PersonaOut | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/estudiantes.py
+++ b/app/schemas/estudiantes.py
@@ -1,13 +1,28 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.schemas.personas import PersonaCreate, PersonaOut
+
 
 class EstudianteBase(BaseModel):
-    persona_id: int = Field(..., gt=0)
     codigo_est: str = Field(..., min_length=1, max_length=50)
 
+
 class EstudianteCreate(EstudianteBase):
-    pass
+    persona_id: int | None = Field(default=None, gt=0)
+    persona: PersonaCreate | None = None
+
+    @model_validator(mode="after")
+    def check_persona_reference(self) -> "EstudianteCreate":
+        persona_id_provided = self.persona_id is not None
+        persona_object_provided = self.persona is not None
+        if persona_id_provided == persona_object_provided:
+            raise ValueError("Debe proporcionar únicamente persona_id o persona")
+        return self
+
 
 class EstudianteOut(EstudianteBase):
     id: int
+    persona_id: int
+    persona: PersonaOut | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,3 @@
+"""Service layer helpers for reusable business logic."""
+
+__all__ = ["personas"]

--- a/app/services/personas.py
+++ b/app/services/personas.py
@@ -1,0 +1,44 @@
+"""Helpers for working with personas within transactional flows."""
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.db.models import CIPersona, Persona
+from app.schemas.personas import PersonaCreate
+
+
+def create_persona(db: Session, data: PersonaCreate) -> Persona:
+    """Create a :class:`Persona` and its CI record when provided.
+
+    The function mirrors the behaviour of the ``/personas`` endpoint so it can be
+    reused by other routes that need to create a ``Persona`` as part of a wider
+    transaction.
+    """
+
+    if data.ci_numero:
+        existe_ci = db.query(CIPersona).filter(CIPersona.ci_numero == data.ci_numero).first()
+        if existe_ci:
+            raise HTTPException(status_code=400, detail="CI ya registrado")
+
+    persona = Persona(
+        nombres=data.nombres,
+        apellidos=data.apellidos,
+        sexo=data.sexo,
+        fecha_nacimiento=data.fecha_nacimiento,
+        celular=data.celular,
+        direccion=data.direccion,
+    )
+    db.add(persona)
+    db.flush()
+
+    if data.ci_numero:
+        db.add(
+            CIPersona(
+                persona_id=persona.id,
+                ci_numero=data.ci_numero,
+                ci_complemento=data.ci_complemento,
+                ci_expedicion=data.ci_expedicion,
+            )
+        )
+
+    return persona

--- a/tests/test_estudiantes_docentes_creation.py
+++ b/tests/test_estudiantes_docentes_creation.py
@@ -1,0 +1,162 @@
+import sys
+import types
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide a lightweight stub for ``mysql.connector`` so importing the API modules
+# does not require the optional MySQL dependency during the tests.
+mysql_module = types.ModuleType("mysql")
+connector_module = types.ModuleType("mysql.connector")
+connector_module.apilevel = "2.0"
+connector_module.threadsafety = 1
+connector_module.paramstyle = "pyformat"
+
+
+def _mysql_connect(*args, **kwargs):  # pragma: no cover - defensive stub
+    raise RuntimeError("mysql connector is not available in the test environment")
+
+
+connector_module.connect = _mysql_connect
+mysql_module.connector = connector_module
+sys.modules.setdefault("mysql", mysql_module)
+sys.modules.setdefault("mysql.connector", connector_module)
+
+from app.api.v1.docentes import crear_docente
+from app.api.v1.estudiantes import crear_estudiante
+from app.db import models
+from app.db.base import Base
+from app.schemas.docentes import DocenteCreate
+from app.schemas.estudiantes import EstudianteCreate
+from app.schemas.personas import PersonaCreate
+
+
+def create_test_engine():
+    return create_engine("sqlite+pysqlite:///:memory:", future=True)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_test_engine()
+    Base.metadata.create_all(engine)
+    TestingSession = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    session = TestingSession()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def build_persona_payload(ci: str | None = None) -> PersonaCreate:
+    return PersonaCreate(
+        nombres="Ana",
+        apellidos="Pérez",
+        sexo=models.SexoEnum.FEMENINO,
+        fecha_nacimiento=date(2000, 1, 1),
+        celular="78945612",
+        direccion="Av. Siempre Viva",
+        ci_numero=ci,
+        ci_complemento=None,
+        ci_expedicion="LP" if ci else None,
+    )
+
+
+def test_crear_estudiante_con_persona_id(db_session):
+    persona = models.Persona(
+        nombres="Luis",
+        apellidos="Torrez",
+        sexo=models.SexoEnum.MASCULINO,
+        fecha_nacimiento=date(1999, 5, 20),
+    )
+    db_session.add(persona)
+    db_session.commit()
+
+    payload = EstudianteCreate(persona_id=persona.id, codigo_est="EST-001")
+
+    estudiante = crear_estudiante(payload, db_session)
+
+    assert estudiante.id is not None
+    assert estudiante.persona_id == persona.id
+    assert estudiante.persona is not None
+    assert estudiante.codigo_est == "EST-001"
+
+
+def test_crear_estudiante_con_persona_nueva(db_session):
+    payload = EstudianteCreate(persona=build_persona_payload(ci="CI-123"), codigo_est="EST-002")
+
+    estudiante = crear_estudiante(payload, db_session)
+
+    assert estudiante.persona is not None
+    assert estudiante.persona.ci is not None
+    assert estudiante.persona.ci.ci_numero == "CI-123"
+
+
+def test_crear_estudiante_con_ci_duplicado(db_session):
+    crear_estudiante(
+        EstudianteCreate(persona=build_persona_payload(ci="CI-777"), codigo_est="EST-100"),
+        db_session,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        crear_estudiante(
+            EstudianteCreate(persona=build_persona_payload(ci="CI-777"), codigo_est="EST-101"),
+            db_session,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "CI ya registrado"
+
+
+def test_crear_docente_con_persona_id(db_session):
+    persona = models.Persona(
+        nombres="Rosa",
+        apellidos="García",
+        sexo=models.SexoEnum.FEMENINO,
+        fecha_nacimiento=date(1985, 8, 12),
+    )
+    db_session.add(persona)
+    db_session.commit()
+
+    payload = DocenteCreate(persona_id=persona.id, titulo="Lic.", profesion="Educación")
+
+    docente = crear_docente(payload, db_session, None)
+
+    assert docente.id is not None
+    assert docente.persona_id == persona.id
+    assert docente.persona is not None
+    assert docente.titulo == "Lic."
+
+
+def test_crear_docente_con_persona_nueva(db_session):
+    payload = DocenteCreate(persona=build_persona_payload(ci="CI-888"), titulo="Ing.")
+
+    docente = crear_docente(payload, db_session, None)
+
+    assert docente.persona is not None
+    assert docente.persona.ci is not None
+    assert docente.persona.ci.ci_numero == "CI-888"
+
+
+def test_crear_docente_con_ci_duplicado(db_session):
+    crear_estudiante(
+        EstudianteCreate(persona=build_persona_payload(ci="CI-999"), codigo_est="EST-200"),
+        db_session,
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        crear_docente(
+            DocenteCreate(persona=build_persona_payload(ci="CI-999"), titulo="Lic."),
+            db_session,
+            None,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.detail == "CI ya registrado"

--- a/tests/test_schemas_serialization.py
+++ b/tests/test_schemas_serialization.py
@@ -1,4 +1,5 @@
 import sys
+from datetime import date
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -9,22 +10,40 @@ from app.schemas.estudiantes import EstudianteOut
 
 
 def test_estudiante_out_accepts_orm_objects():
-    estudiante = models.Estudiante(id=1, persona_id=2, codigo_est="ABC123")
+    persona = models.Persona(
+        id=2,
+        nombres="Ana",
+        apellidos="Pérez",
+        sexo=models.SexoEnum.FEMENINO,
+        fecha_nacimiento=date(2000, 1, 1),
+    )
+    estudiante = models.Estudiante(id=1, persona_id=persona.id, codigo_est="ABC123")
+    estudiante.persona = persona
 
     schema = EstudianteOut.model_validate(estudiante)
 
     assert schema.id == 1
     assert schema.persona_id == 2
     assert schema.codigo_est == "ABC123"
+    assert schema.persona is not None
+    assert schema.persona.id == persona.id
 
 
 def test_docente_out_accepts_orm_objects():
+    persona = models.Persona(
+        id=3,
+        nombres="Juan",
+        apellidos="Suárez",
+        sexo=models.SexoEnum.MASCULINO,
+        fecha_nacimiento=date(1995, 7, 1),
+    )
     docente = models.Docente(
         id=7,
-        persona_id=3,
+        persona_id=persona.id,
         titulo="Lic.",
         profesion="Educación",
     )
+    docente.persona = persona
 
     schema = DocenteOut.model_validate(docente)
 
@@ -32,3 +51,5 @@ def test_docente_out_accepts_orm_objects():
     assert schema.persona_id == 3
     assert schema.titulo == "Lic."
     assert schema.profesion == "Educación"
+    assert schema.persona is not None
+    assert schema.persona.id == persona.id


### PR DESCRIPTION
## Summary
- allow estudiante and docente creation payloads to accept either a persona_id or embedded persona data with validation
- share persona creation logic across endpoints and return related persona information in responses
- add unit tests covering both creation paths and CI duplication handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd7d3441b083259caa7140339df9e9