### PR TITLE
Enforce non-null student codes

### DIFF
--- a/alembic/versions/b78bd934f74c_enforce_codigo_est_not_null.py
+++ b/alembic/versions/b78bd934f74c_enforce_codigo_est_not_null.py
@@ -1,0 +1,62 @@
+"""Enforce ``estudiantes.codigo_est`` not null."""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b78bd934f74c"
+down_revision: Union[str, Sequence[str], None] = "f331211262dc"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    estudiantes = sa.table(
+        "estudiantes",
+        sa.column("id", sa.Integer()),
+        sa.column("codigo_est", sa.String(length=30)),
+    )
+
+    result = conn.execute(
+        sa.select(estudiantes.c.id).where(estudiantes.c.codigo_est.is_(None))
+    ).all()
+
+    for (estudiante_id,) in result:
+        conn.execute(
+            sa.update(estudiantes)
+            .where(estudiantes.c.id == estudiante_id)
+            .values(codigo_est=f"AUTO_NULL_FIX_{estudiante_id}")
+        )
+
+    op.alter_column(
+        "estudiantes",
+        "codigo_est",
+        existing_type=sa.String(length=30),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    estudiantes = sa.table(
+        "estudiantes",
+        sa.column("id", sa.Integer()),
+        sa.column("codigo_est", sa.String(length=30)),
+    )
+
+    conn.execute(
+        sa.update(estudiantes)
+        .where(estudiantes.c.codigo_est.like("AUTO_NULL_FIX_%"))
+        .values(codigo_est=None)
+    )
+
+    op.alter_column(
+        "estudiantes",
+        "codigo_est",
+        existing_type=sa.String(length=30),
+        nullable=True,
+    )

--- a/app/api/v1/estudiantes.py
+++ b/app/api/v1/estudiantes.py
@@ -11,12 +11,16 @@ router = APIRouter(tags=["estudiantes"])
 
 @router.post("/", response_model=EstudianteOut, status_code=201)
 def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
+    codigo_est = payload.codigo_est.strip()
+    if not codigo_est:
+        raise HTTPException(status_code=400, detail="codigo_est es requerido")
+
     if payload.persona is not None:
         try:
             persona = create_persona(db, payload.persona)
             existe = (
                 db.query(models.Estudiante)
-                .filter(models.Estudiante.codigo_est == payload.codigo_est)
+                .filter(models.Estudiante.codigo_est == codigo_est)
                 .first()
             )
             if existe:
@@ -24,7 +28,7 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
 
             est = models.Estudiante(
                 persona_id=persona.id,
-                codigo_est=payload.codigo_est,
+                codigo_est=codigo_est,
             )
             db.add(est)
             db.commit()
@@ -42,13 +46,13 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
 
     existe = (
         db.query(models.Estudiante)
-        .filter(models.Estudiante.codigo_est == payload.codigo_est)
+        .filter(models.Estudiante.codigo_est == codigo_est)
         .first()
     )
     if existe:
         raise HTTPException(status_code=400, detail="codigo_est ya existe")
 
-    est = models.Estudiante(persona_id=payload.persona_id, codigo_est=payload.codigo_est)
+    est = models.Estudiante(persona_id=payload.persona_id, codigo_est=codigo_est)
     db.add(est)
     db.commit()
     db.refresh(est)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -228,7 +228,7 @@ class Estudiante(Base):
     persona_id: Mapped[int] = mapped_column(
         ForeignKey("personas.id", ondelete="CASCADE"), nullable=False
     )
-    codigo_est: Mapped[str | None] = mapped_column(String(30), unique=True)
+    codigo_est: Mapped[str] = mapped_column(String(30), unique=True, nullable=False)
 
     persona: Mapped[Persona] = relationship("Persona")
 

--- a/tests/test_estudiantes_api.py
+++ b/tests/test_estudiantes_api.py
@@ -1,0 +1,119 @@
+import sys
+import types
+from datetime import date
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub optional MySQL dependency expected by the application modules.
+mysql_module = types.ModuleType("mysql")
+connector_module = types.ModuleType("mysql.connector")
+connector_module.apilevel = "2.0"
+connector_module.threadsafety = 1
+connector_module.paramstyle = "pyformat"
+connector_module.Error = RuntimeError
+connector_module.OperationalError = RuntimeError
+connector_module.InterfaceError = RuntimeError
+
+
+def _mysql_connect(*args, **kwargs):  # pragma: no cover - defensive stub
+    raise RuntimeError("mysql connector is not available in the test environment")
+
+
+connector_module.connect = _mysql_connect
+mysql_module.connector = connector_module
+sys.modules.setdefault("mysql", mysql_module)
+sys.modules.setdefault("mysql.connector", connector_module)
+
+from app.api.deps import get_db
+from app.db import models
+from app.db.base import Base
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite+pysqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    TestingSession = sessionmaker(
+        bind=engine, autoflush=False, autocommit=False, future=True
+    )
+
+    def override_get_db():
+        session = TestingSession()
+        try:
+            yield session
+            session.commit()
+        finally:
+            session.close()
+
+    original_startup = list(app.router.on_startup)
+    original_shutdown = list(app.router.on_shutdown)
+    app.router.on_startup.clear()
+    app.router.on_shutdown.clear()
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        with TestClient(app) as test_client:
+            yield test_client
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+        app.router.on_startup.clear()
+        app.router.on_startup.extend(original_startup)
+        app.router.on_shutdown.clear()
+        app.router.on_shutdown.extend(original_shutdown)
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_crear_estudiante_con_codigo_valido(client):
+    payload = {
+        "codigo_est": "EST-500",
+        "persona": {
+            "nombres": "Laura",
+            "apellidos": "Mendoza",
+            "sexo": models.SexoEnum.FEMENINO.value,
+            "fecha_nacimiento": date(2004, 6, 15).isoformat(),
+            "celular": "71234567",
+            "direccion": "Av. Central",
+            "ci_numero": "CI-500",
+            "ci_expedicion": "LP",
+        },
+    }
+
+    response = client.post("/api/v1/estudiantes/", json=payload)
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["codigo_est"] == "EST-500"
+    assert body["persona_id"] > 0
+    assert body["persona"]["nombres"] == "Laura"
+    assert body["persona"]["sexo"] == models.SexoEnum.FEMENINO.short_code
+
+
+def test_crear_estudiante_sin_codigo_retorna_400(client):
+    payload = {
+        "codigo_est": "   ",
+        "persona": {
+            "nombres": "Mario",
+            "apellidos": "Gutiérrez",
+            "sexo": models.SexoEnum.MASCULINO.value,
+            "fecha_nacimiento": date(2003, 3, 10).isoformat(),
+        },
+    }
+
+    response = client.post("/api/v1/estudiantes/", json=payload)
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "codigo_est es requerido"}


### PR DESCRIPTION
## Summary
- ensure existing students without `codigo_est` receive temporary codes and make the column non-nullable
- require the API to strip and validate the provided `codigo_est` before persisting it
- add API tests covering successful creation and a 400 response when the code is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd8fc0f45c832594b63e3f49d0ac39