### PR TITLE
Align estudiantes schema with production data

### DIFF
--- a/alembic/versions/3d9c7423011c_merge_estudiantes_schema.py
+++ b/alembic/versions/3d9c7423011c_merge_estudiantes_schema.py
@@ -1,0 +1,127 @@
+"""merge estudiantes schema.
+
+Revision ID: 3d9c7423011c
+Revises: a79045946885, 69e0d76d4c8b, ce370f07d10f
+Create Date: 2025-10-05 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "3d9c7423011c"
+down_revision: Union[str, Sequence[str], None] = (
+    "a79045946885",
+    "69e0d76d4c8b",
+    "ce370f07d10f",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(bind, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _get_metadata(bind, table_name: str) -> tuple[set[str], set[str], set[str]]:
+    inspector = sa.inspect(bind)
+    columns = {col["name"] for col in inspector.get_columns(table_name)}
+    uniques = {uc["name"] for uc in inspector.get_unique_constraints(table_name) if uc.get("name")}
+    fks = {fk["name"] for fk in inspector.get_foreign_keys(table_name) if fk.get("name")}
+    return columns, uniques, fks
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "estudiantes"):
+        return
+
+    columns, uniques, fks = _get_metadata(bind, "estudiantes")
+
+    fk_names_to_drop = [
+        name
+        for name in ("fk_estudiantes_persona", "estudiantes_ibfk_1")
+        if name in fks
+    ]
+
+    with op.batch_alter_table("estudiantes") as batch_op:
+        for fk_name in fk_names_to_drop:
+            batch_op.drop_constraint(fk_name, type_="foreignkey")
+        if "codigo_est" not in columns:
+            batch_op.add_column(sa.Column("codigo_est", sa.String(length=30), nullable=True))
+        if "codigo_rude" in columns and "uq_estudiantes_rude" in uniques:
+            batch_op.drop_constraint("uq_estudiantes_rude", type_="unique")
+
+    if "codigo_rude" in columns:
+        op.execute(
+            sa.text(
+                "UPDATE estudiantes SET codigo_est = codigo_rude "
+                "WHERE codigo_est IS NULL OR codigo_est = ''"
+            )
+        )
+
+    columns, uniques, fks = _get_metadata(bind, "estudiantes")
+
+    with op.batch_alter_table("estudiantes") as batch_op:
+        if "codigo_rude" in columns:
+            batch_op.drop_column("codigo_rude")
+        batch_op.alter_column(
+            "codigo_est",
+            existing_type=sa.String(length=30),
+            nullable=False,
+        )
+        if "uq_est_codigo" not in uniques:
+            batch_op.create_unique_constraint("uq_est_codigo", ["codigo_est"])
+        if "fk_estudiantes_persona" not in fks:
+            batch_op.create_foreign_key(
+                "fk_estudiantes_persona",
+                "personas",
+                ["persona_id"],
+                ["id"],
+                ondelete="CASCADE",
+            )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "estudiantes"):
+        return
+
+    columns, uniques, fks = _get_metadata(bind, "estudiantes")
+
+    with op.batch_alter_table("estudiantes") as batch_op:
+        if "fk_estudiantes_persona" in fks:
+            batch_op.drop_constraint("fk_estudiantes_persona", type_="foreignkey")
+        if "uq_est_codigo" in uniques:
+            batch_op.drop_constraint("uq_est_codigo", type_="unique")
+        if "codigo_rude" not in columns:
+            batch_op.add_column(sa.Column("codigo_rude", sa.String(length=30), nullable=True))
+
+    op.execute(
+        sa.text("UPDATE estudiantes SET codigo_rude = codigo_est WHERE codigo_est IS NOT NULL")
+    )
+
+    columns, uniques, fks = _get_metadata(bind, "estudiantes")
+
+    with op.batch_alter_table("estudiantes") as batch_op:
+        batch_op.alter_column(
+            "codigo_est",
+            existing_type=sa.String(length=30),
+            nullable=True,
+        )
+        if "codigo_est" in columns:
+            batch_op.drop_column("codigo_est")
+        if "uq_estudiantes_rude" not in uniques:
+            batch_op.create_unique_constraint("uq_estudiantes_rude", ["codigo_rude"])
+        if "fk_estudiantes_persona" not in fks:
+            batch_op.create_foreign_key(
+                "fk_estudiantes_persona",
+                "personas",
+                ["persona_id"],
+                ["id"],
+            )

--- a/app/api/v1/estudiantes.py
+++ b/app/api/v1/estudiantes.py
@@ -1,6 +1,8 @@
+from datetime import date
+from typing import List, Optional
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
-from typing import List, Optional
 
 from app.api.deps import get_db
 from app.db import models
@@ -14,6 +16,10 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
     codigo_est = payload.codigo_est.strip()
     if not codigo_est:
         raise HTTPException(status_code=400, detail="codigo_est es requerido")
+
+    ingreso = payload.anio_ingreso or date.today().year
+    situacion = payload.situacion.value if hasattr(payload.situacion, "value") else payload.situacion
+    estado = payload.estado.value if hasattr(payload.estado, "value") else payload.estado
 
     if payload.persona is not None:
         try:
@@ -29,6 +35,9 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
             est = models.Estudiante(
                 persona_id=persona.id,
                 codigo_est=codigo_est,
+                anio_ingreso=ingreso,
+                situacion=situacion,
+                estado=estado,
             )
             db.add(est)
             db.commit()
@@ -53,6 +62,9 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
         raise HTTPException(status_code=400, detail="codigo_est ya existe")
 
     est = models.Estudiante(persona_id=payload.persona_id, codigo_est=codigo_est)
+    est.anio_ingreso = ingreso
+    est.situacion = situacion
+    est.estado = estado
     db.add(est)
     db.commit()
     db.refresh(est)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -221,6 +221,22 @@ class AuditLog(Base):
     actor: Mapped[Usuario | None] = relationship("Usuario")
 
 
+class SituacionEstudianteEnum(str, Enum):
+    """Academic status for :class:`Estudiante` records."""
+
+    REGULAR = "REGULAR"
+    RETIRADO = "RETIRADO"
+    EGRESADO = "EGRESADO"
+    CONDICIONAL = "CONDICIONAL"
+
+
+class EstadoEstudianteEnum(str, Enum):
+    """Lifecycle status for :class:`Estudiante` records."""
+
+    ACTIVO = "ACTIVO"
+    INACTIVO = "INACTIVO"
+
+
 class Estudiante(Base):
     __tablename__ = "estudiantes"
 
@@ -228,11 +244,41 @@ class Estudiante(Base):
     persona_id: Mapped[int] = mapped_column(
         ForeignKey("personas.id", ondelete="CASCADE"), nullable=False
     )
-    codigo_est: Mapped[str] = mapped_column(String(30), unique=True, nullable=False)
+    codigo_est: Mapped[str] = mapped_column(
+        String(30),
+        nullable=False,
+        unique=True,
+    )
+    anio_ingreso: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=0, server_default="0"
+    )
+    situacion: Mapped[str] = mapped_column(
+        SAEnum(
+            SituacionEstudianteEnum,
+            name="est_situacion_enum",
+            native_enum=False,
+        ),
+        nullable=False,
+        default=SituacionEstudianteEnum.REGULAR.value,
+        server_default=SituacionEstudianteEnum.REGULAR.value,
+    )
+    estado: Mapped[str] = mapped_column(
+        SAEnum(
+            EstadoEstudianteEnum,
+            name="est_estado_enum",
+            native_enum=False,
+        ),
+        nullable=False,
+        default=EstadoEstudianteEnum.ACTIVO.value,
+        server_default=EstadoEstudianteEnum.ACTIVO.value,
+    )
 
     persona: Mapped[Persona] = relationship("Persona")
 
-    __table_args__ = (UniqueConstraint("codigo_est", name="uq_est_codigo"),)
+    __table_args__ = (
+        UniqueConstraint("codigo_est", name="uq_est_codigo"),
+        UniqueConstraint("persona_id", name="uq_estudiantes_persona"),
+    )
 
 
 class TipoEvalEnum(str, Enum):

--- a/app/schemas/estudiantes.py
+++ b/app/schemas/estudiantes.py
@@ -1,10 +1,33 @@
+from enum import Enum
+from datetime import date
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.schemas.personas import PersonaCreate, PersonaOut
 
 
+class SituacionEstudianteEnum(str, Enum):
+    REGULAR = "REGULAR"
+    RETIRADO = "RETIRADO"
+    EGRESADO = "EGRESADO"
+    CONDICIONAL = "CONDICIONAL"
+
+
+class EstadoEstudianteEnum(str, Enum):
+    ACTIVO = "ACTIVO"
+    INACTIVO = "INACTIVO"
+
+
 class EstudianteBase(BaseModel):
     codigo_est: str = Field(..., min_length=1, max_length=50)
+    anio_ingreso: int | None = Field(
+        default=None,
+        ge=1900,
+        le=date.today().year + 1,
+        description="Año de ingreso al establecimiento",
+    )
+    situacion: SituacionEstudianteEnum = SituacionEstudianteEnum.REGULAR
+    estado: EstadoEstudianteEnum = EstadoEstudianteEnum.ACTIVO
 
 
 class EstudianteCreate(EstudianteBase):

--- a/tests/test_estudiantes_api.py
+++ b/tests/test_estudiantes_api.py
@@ -100,6 +100,9 @@ def test_crear_estudiante_con_codigo_valido(client):
     assert body["persona_id"] > 0
     assert body["persona"]["nombres"] == "Laura"
     assert body["persona"]["sexo"] == models.SexoEnum.FEMENINO.short_code
+    assert body["anio_ingreso"] == date.today().year
+    assert body["situacion"] == "REGULAR"
+    assert body["estado"] == "ACTIVO"
 
 
 def test_crear_estudiante_sin_codigo_retorna_400(client):

--- a/tests/test_estudiantes_docentes_creation.py
+++ b/tests/test_estudiantes_docentes_creation.py
@@ -87,6 +87,9 @@ def test_crear_estudiante_con_persona_id(db_session):
     assert estudiante.persona_id == persona.id
     assert estudiante.persona is not None
     assert estudiante.codigo_est == "EST-001"
+    assert estudiante.anio_ingreso == date.today().year
+    assert estudiante.situacion == models.SituacionEstudianteEnum.REGULAR.value
+    assert estudiante.estado == models.EstadoEstudianteEnum.ACTIVO.value
 
 
 def test_crear_estudiante_con_persona_nueva(db_session):
@@ -97,6 +100,9 @@ def test_crear_estudiante_con_persona_nueva(db_session):
     assert estudiante.persona is not None
     assert estudiante.persona.ci is not None
     assert estudiante.persona.ci.ci_numero == "CI-123"
+    assert estudiante.anio_ingreso == date.today().year
+    assert estudiante.situacion == models.SituacionEstudianteEnum.REGULAR.value
+    assert estudiante.estado == models.EstadoEstudianteEnum.ACTIVO.value
 
 
 def test_crear_estudiante_con_ci_duplicado(db_session):

--- a/tests/test_schemas_serialization.py
+++ b/tests/test_schemas_serialization.py
@@ -17,7 +17,14 @@ def test_estudiante_out_accepts_orm_objects():
         sexo=models.SexoEnum.FEMENINO,
         fecha_nacimiento=date(2000, 1, 1),
     )
-    estudiante = models.Estudiante(id=1, persona_id=persona.id, codigo_est="ABC123")
+    estudiante = models.Estudiante(
+        id=1,
+        persona_id=persona.id,
+        codigo_est="ABC123",
+        anio_ingreso=2024,
+        situacion=models.SituacionEstudianteEnum.REGULAR.value,
+        estado=models.EstadoEstudianteEnum.ACTIVO.value,
+    )
     estudiante.persona = persona
 
     schema = EstudianteOut.model_validate(estudiante)
@@ -25,6 +32,9 @@ def test_estudiante_out_accepts_orm_objects():
     assert schema.id == 1
     assert schema.persona_id == 2
     assert schema.codigo_est == "ABC123"
+    assert schema.anio_ingreso == 2024
+    assert schema.situacion == models.SituacionEstudianteEnum.REGULAR
+    assert schema.estado == models.EstadoEstudianteEnum.ACTIVO
     assert schema.persona is not None
     assert schema.persona.id == persona.id
 


### PR DESCRIPTION
## Summary
- extend the Estudiante model and API to capture ingreso, situacion and estado while defaulting values for backwards compatibility
- expose the new student attributes through Pydantic schemas and update tests to assert the richer response payloads
- add a defensive Alembic merge migration that renames codigo_rude to codigo_est and restores the expected constraints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd996d35348325a67b4841b343cfd2