### PR TITLE
Align estudiantes codigo field with codigo_rude

### DIFF
--- a/app/api/v1/estudiantes.py
+++ b/app/api/v1/estudiantes.py
@@ -13,9 +13,9 @@ router = APIRouter(tags=["estudiantes"])
 
 @router.post("/", response_model=EstudianteOut, status_code=201)
 def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
-    codigo_est = payload.codigo_est.strip()
-    if not codigo_est:
-        raise HTTPException(status_code=400, detail="codigo_est es requerido")
+    codigo_rude = payload.codigo_rude.strip()
+    if not codigo_rude:
+        raise HTTPException(status_code=400, detail="codigo_rude es requerido")
 
     ingreso = payload.anio_ingreso or date.today().year
     situacion = payload.situacion.value if hasattr(payload.situacion, "value") else payload.situacion
@@ -26,15 +26,15 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
             persona = create_persona(db, payload.persona)
             existe = (
                 db.query(models.Estudiante)
-                .filter(models.Estudiante.codigo_est == codigo_est)
+                .filter(models.Estudiante.codigo_rude == codigo_rude)
                 .first()
             )
             if existe:
-                raise HTTPException(status_code=400, detail="codigo_est ya existe")
+                raise HTTPException(status_code=400, detail="codigo_rude ya existe")
 
             est = models.Estudiante(
                 persona_id=persona.id,
-                codigo_est=codigo_est,
+                codigo_rude=codigo_rude,
                 anio_ingreso=ingreso,
                 situacion=situacion,
                 estado=estado,
@@ -55,13 +55,13 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
 
     existe = (
         db.query(models.Estudiante)
-        .filter(models.Estudiante.codigo_est == codigo_est)
+        .filter(models.Estudiante.codigo_rude == codigo_rude)
         .first()
     )
     if existe:
-        raise HTTPException(status_code=400, detail="codigo_est ya existe")
+        raise HTTPException(status_code=400, detail="codigo_rude ya existe")
 
-    est = models.Estudiante(persona_id=payload.persona_id, codigo_est=codigo_est)
+    est = models.Estudiante(persona_id=payload.persona_id, codigo_rude=codigo_rude)
     est.anio_ingreso = ingreso
     est.situacion = situacion
     est.estado = estado
@@ -75,13 +75,13 @@ def crear_estudiante(payload: EstudianteCreate, db: Session = Depends(get_db)):
 def listar_estudiantes(
     db: Session = Depends(get_db),
     persona_id: Optional[int] = Query(None, gt=0),
-    codigo_est: Optional[str] = Query(None, min_length=1),
+    codigo_rude: Optional[str] = Query(None, min_length=1),
     limit: int = Query(100, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
     q = db.query(models.Estudiante)
     if persona_id: q = q.filter(models.Estudiante.persona_id == persona_id)
-    if codigo_est: q = q.filter(models.Estudiante.codigo_est == codigo_est)
+    if codigo_rude: q = q.filter(models.Estudiante.codigo_rude == codigo_rude)
     return q.offset(offset).limit(limit).all()
 
 @router.get("/{estudiante_id}", response_model=EstudianteOut)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -244,7 +244,7 @@ class Estudiante(Base):
     persona_id: Mapped[int] = mapped_column(
         ForeignKey("personas.id", ondelete="CASCADE"), nullable=False
     )
-    codigo_est: Mapped[str] = mapped_column(
+    codigo_rude: Mapped[str] = mapped_column(
         String(30),
         nullable=False,
         unique=True,
@@ -276,7 +276,7 @@ class Estudiante(Base):
     persona: Mapped[Persona] = relationship("Persona")
 
     __table_args__ = (
-        UniqueConstraint("codigo_est", name="uq_est_codigo"),
+        UniqueConstraint("codigo_rude", name="uq_estudiantes_rude"),
         UniqueConstraint("persona_id", name="uq_estudiantes_persona"),
     )
 

--- a/app/schemas/estudiantes.py
+++ b/app/schemas/estudiantes.py
@@ -19,7 +19,7 @@ class EstadoEstudianteEnum(str, Enum):
 
 
 class EstudianteBase(BaseModel):
-    codigo_est: str = Field(..., min_length=1, max_length=50)
+    codigo_rude: str = Field(..., min_length=1, max_length=50)
     anio_ingreso: int | None = Field(
         default=None,
         ge=1900,

--- a/tests/test_estudiantes_api.py
+++ b/tests/test_estudiantes_api.py
@@ -79,7 +79,7 @@ def client():
 
 def test_crear_estudiante_con_codigo_valido(client):
     payload = {
-        "codigo_est": "EST-500",
+        "codigo_rude": "RUDE-500",
         "persona": {
             "nombres": "Laura",
             "apellidos": "Mendoza",
@@ -96,7 +96,7 @@ def test_crear_estudiante_con_codigo_valido(client):
 
     assert response.status_code == 201
     body = response.json()
-    assert body["codigo_est"] == "EST-500"
+    assert body["codigo_rude"] == "RUDE-500"
     assert body["persona_id"] > 0
     assert body["persona"]["nombres"] == "Laura"
     assert body["persona"]["sexo"] == models.SexoEnum.FEMENINO.short_code
@@ -107,7 +107,7 @@ def test_crear_estudiante_con_codigo_valido(client):
 
 def test_crear_estudiante_sin_codigo_retorna_400(client):
     payload = {
-        "codigo_est": "   ",
+        "codigo_rude": "   ",
         "persona": {
             "nombres": "Mario",
             "apellidos": "Gutiérrez",
@@ -119,4 +119,4 @@ def test_crear_estudiante_sin_codigo_retorna_400(client):
     response = client.post("/api/v1/estudiantes/", json=payload)
 
     assert response.status_code == 400
-    assert response.json() == {"detail": "codigo_est es requerido"}
+    assert response.json() == {"detail": "codigo_rude es requerido"}

--- a/tests/test_estudiantes_docentes_creation.py
+++ b/tests/test_estudiantes_docentes_creation.py
@@ -79,21 +79,21 @@ def test_crear_estudiante_con_persona_id(db_session):
     db_session.add(persona)
     db_session.commit()
 
-    payload = EstudianteCreate(persona_id=persona.id, codigo_est="EST-001")
+    payload = EstudianteCreate(persona_id=persona.id, codigo_rude="RUDE-001")
 
     estudiante = crear_estudiante(payload, db_session)
 
     assert estudiante.id is not None
     assert estudiante.persona_id == persona.id
     assert estudiante.persona is not None
-    assert estudiante.codigo_est == "EST-001"
+    assert estudiante.codigo_rude == "RUDE-001"
     assert estudiante.anio_ingreso == date.today().year
     assert estudiante.situacion == models.SituacionEstudianteEnum.REGULAR.value
     assert estudiante.estado == models.EstadoEstudianteEnum.ACTIVO.value
 
 
 def test_crear_estudiante_con_persona_nueva(db_session):
-    payload = EstudianteCreate(persona=build_persona_payload(ci="CI-123"), codigo_est="EST-002")
+    payload = EstudianteCreate(persona=build_persona_payload(ci="CI-123"), codigo_rude="RUDE-002")
 
     estudiante = crear_estudiante(payload, db_session)
 
@@ -107,13 +107,13 @@ def test_crear_estudiante_con_persona_nueva(db_session):
 
 def test_crear_estudiante_con_ci_duplicado(db_session):
     crear_estudiante(
-        EstudianteCreate(persona=build_persona_payload(ci="CI-777"), codigo_est="EST-100"),
+        EstudianteCreate(persona=build_persona_payload(ci="CI-777"), codigo_rude="RUDE-100"),
         db_session,
     )
 
     with pytest.raises(HTTPException) as excinfo:
         crear_estudiante(
-            EstudianteCreate(persona=build_persona_payload(ci="CI-777"), codigo_est="EST-101"),
+            EstudianteCreate(persona=build_persona_payload(ci="CI-777"), codigo_rude="RUDE-101"),
             db_session,
         )
 
@@ -153,7 +153,7 @@ def test_crear_docente_con_persona_nueva(db_session):
 
 def test_crear_docente_con_ci_duplicado(db_session):
     crear_estudiante(
-        EstudianteCreate(persona=build_persona_payload(ci="CI-999"), codigo_est="EST-200"),
+        EstudianteCreate(persona=build_persona_payload(ci="CI-999"), codigo_rude="RUDE-200"),
         db_session,
     )
 

--- a/tests/test_schemas_serialization.py
+++ b/tests/test_schemas_serialization.py
@@ -20,7 +20,7 @@ def test_estudiante_out_accepts_orm_objects():
     estudiante = models.Estudiante(
         id=1,
         persona_id=persona.id,
-        codigo_est="ABC123",
+        codigo_rude="ABC123",
         anio_ingreso=2024,
         situacion=models.SituacionEstudianteEnum.REGULAR.value,
         estado=models.EstadoEstudianteEnum.ACTIVO.value,
@@ -31,7 +31,7 @@ def test_estudiante_out_accepts_orm_objects():
 
     assert schema.id == 1
     assert schema.persona_id == 2
-    assert schema.codigo_est == "ABC123"
+    assert schema.codigo_rude == "ABC123"
     assert schema.anio_ingreso == 2024
     assert schema.situacion == models.SituacionEstudianteEnum.REGULAR
     assert schema.estado == models.EstadoEstudianteEnum.ACTIVO


### PR DESCRIPTION
## Summary
- replace student identifier handling to use `codigo_rude` throughout the API, schema, and ORM model
- update tests to exercise the new `codigo_rude` field expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dda39cae648325b1a080315c2910aa