### PR TITLE
Sanitize legacy student enrollment years

### DIFF
--- a/app/schemas/estudiantes.py
+++ b/app/schemas/estudiantes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from datetime import date
 
@@ -47,5 +49,48 @@ class EstudianteOut(EstudianteBase):
     id: int
     persona_id: int
     persona: PersonaOut | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalise_anio_ingreso(cls, data: "EstudianteOut" | dict) -> "EstudianteOut" | dict:
+        """Ensure ``anio_ingreso`` values falling outside the accepted range are nulled.
+
+        Legacy datasets may contain ``0`` or other out-of-bounds values for the
+        ``anio_ingreso`` column. Those values trigger FastAPI's response model
+        validation because the schema restricts the field to ``[1900, año actual + 1]``.
+        To avoid returning a 500 error we coerce those legacy values to ``None``
+        before field validation runs.
+        """
+
+        def _sanitise(value):
+            if value is None:
+                return None
+            try:
+                year = int(value)
+            except (TypeError, ValueError):
+                return value
+
+            max_year = date.today().year + 1
+            return year if 1900 <= year <= max_year else None
+
+        if isinstance(data, dict):
+            raw_year = data.get("anio_ingreso")
+            normalised = _sanitise(raw_year)
+            if normalised != raw_year:
+                data = dict(data)
+                data["anio_ingreso"] = normalised
+            return data
+
+        raw_year = getattr(data, "anio_ingreso", None)
+        normalised = _sanitise(raw_year)
+        if normalised == raw_year:
+            return data
+
+        coerced = {
+            field_name: getattr(data, field_name, None)
+            for field_name in cls.model_fields
+        }
+        coerced["anio_ingreso"] = normalised
+        return coerced
 
     model_config = ConfigDict(from_attributes=True)

--- a/tests/test_schemas_serialization.py
+++ b/tests/test_schemas_serialization.py
@@ -39,6 +39,31 @@ def test_estudiante_out_accepts_orm_objects():
     assert schema.persona.id == persona.id
 
 
+def test_estudiante_out_sets_invalid_anio_ingreso_to_none():
+    persona = models.Persona(
+        id=5,
+        nombres="Luis",
+        apellidos="Soto",
+        sexo=models.SexoEnum.MASCULINO,
+        fecha_nacimiento=date(2002, 4, 10),
+    )
+    estudiante = models.Estudiante(
+        id=9,
+        persona_id=persona.id,
+        codigo_rude="LEGACY001",
+        anio_ingreso=0,
+        situacion=models.SituacionEstudianteEnum.REGULAR.value,
+        estado=models.EstadoEstudianteEnum.ACTIVO.value,
+    )
+    estudiante.persona = persona
+
+    schema = EstudianteOut.model_validate(estudiante)
+
+    assert schema.anio_ingreso is None
+    # The ORM object should remain untouched; we only sanitise the schema output.
+    assert estudiante.anio_ingreso == 0
+
+
 def test_docente_out_accepts_orm_objects():
     persona = models.Persona(
         id=3,


### PR DESCRIPTION
## Summary
- normalise `EstudianteOut` so legacy enrollment years outside the accepted range become `None` before validation
- add a regression test covering ORM objects with an out-of-bounds `anio_ingreso`

## Testing
- pytest tests/test_schemas_serialization.py

------
https://chatgpt.com/codex/tasks/task_e_68ddac3110c88325a3ebda52209d4d4f