### PR TITLE
Implement soft delete and active-only filtering for materias

### DIFF
--- a/app/api/v1/materias.py
+++ b/app/api/v1/materias.py
@@ -22,20 +22,28 @@ def listar_materias(
     q: str | None = Query(None),
     area: str | None = Query(None),
     estado: str | None = Query(None),
+    incluir_inactivos: bool = Query(False, alias="incluir_inactivos"),
     db: Session = Depends(get_db),
     _: Usuario = Depends(require_view("MATERIAS")),
 ):
     query = db.query(Materia)
+
+    if not estado and not incluir_inactivos:
+        query = query.filter(Materia.estado == "ACTIVO")
+
     if q:
         q_like = f"%{q}%"
         query = query.filter((Materia.nombre.ilike(q_like)) | (Materia.codigo.ilike(q_like)))
     if area:
         query = query.filter(Materia.area.ilike(f"%{area}%"))
+
     if estado:
         estado_norm = estado.strip().upper()
-        if estado_norm not in {"ACTIVO", "INACTIVO"}:
+        if estado_norm not in {"ACTIVO", "INACTIVO", "TODOS"}:
             raise HTTPException(status_code=400, detail="estado inválido")
-        query = query.filter(Materia.estado == estado_norm)
+        if estado_norm != "TODOS":
+            query = query.filter(Materia.estado == estado_norm)
+
     return query.order_by(Materia.nombre.asc()).all()
 
 @router.post("", response_model=MateriaOut, status_code=status.HTTP_201_CREATED)
@@ -45,14 +53,37 @@ def crear_materia(
     _: Usuario = Depends(require_view("MATERIAS")),
 ):
     try:
-        # opcional: check rápido por código duplicado
-        if db.query(Materia).filter(Materia.codigo == data.codigo).first():
-            raise HTTPException(status_code=400, detail="codigo ya existe")
+        existing_codigo = (
+            db.query(Materia).filter(Materia.codigo == data.codigo).first()
+        )
+        if existing_codigo:
+            detail = {
+                "error": "codigo_en_uso",
+                "mensaje": "Código de materia ya registrado.",
+                "materia_id": existing_codigo.id,
+                "estado": existing_codigo.estado,
+            }
+            raise HTTPException(status_code=409, detail=detail)
+
+        existing_nombre = (
+            db.query(Materia).filter(Materia.nombre == data.nombre).first()
+        )
+        if existing_nombre:
+            detail = {
+                "error": "nombre_en_uso",
+                "mensaje": "Nombre de materia ya registrado.",
+                "materia_id": existing_nombre.id,
+                "estado": existing_nombre.estado,
+            }
+            raise HTTPException(status_code=409, detail=detail)
 
         payload = data.model_dump()
-        payload["estado"] = payload["estado"].upper()
-        if payload["estado"] not in {"ACTIVO", "INACTIVO"}:
+        estado_payload = payload.get("estado", "ACTIVO")
+        estado_norm = estado_payload.upper() if estado_payload else "ACTIVO"
+        if estado_norm not in {"ACTIVO", "INACTIVO"}:
             raise HTTPException(status_code=400, detail="estado inválido")
+        payload["estado"] = estado_norm
+
         m = Materia(**payload)
         db.add(m)
         db.commit()
@@ -80,8 +111,34 @@ def editar_materia(
     if not m:
         raise HTTPException(404, "Materia no encontrada")
     if data.codigo and data.codigo != m.codigo:
-        if db.query(Materia).filter(Materia.codigo == data.codigo).first():
-            raise HTTPException(400, "codigo ya existe")
+        existing_codigo = (
+            db.query(Materia)
+            .filter(Materia.codigo == data.codigo, Materia.id != m.id)
+            .first()
+        )
+        if existing_codigo:
+            detail = {
+                "error": "codigo_en_uso",
+                "mensaje": "Código de materia ya registrado.",
+                "materia_id": existing_codigo.id,
+                "estado": existing_codigo.estado,
+            }
+            raise HTTPException(status_code=409, detail=detail)
+
+    if data.nombre and data.nombre != m.nombre:
+        existing_nombre = (
+            db.query(Materia)
+            .filter(Materia.nombre == data.nombre, Materia.id != m.id)
+            .first()
+        )
+        if existing_nombre:
+            detail = {
+                "error": "nombre_en_uso",
+                "mensaje": "Nombre de materia ya registrado.",
+                "materia_id": existing_nombre.id,
+                "estado": existing_nombre.estado,
+            }
+            raise HTTPException(status_code=409, detail=detail)
     for k, v in data.model_dump(exclude_unset=True).items():
         if k == "estado" and v is not None:
             estado_norm = v.upper()
@@ -90,7 +147,8 @@ def editar_materia(
             setattr(m, k, estado_norm)
         else:
             setattr(m, k, v)
-    db.commit(); db.refresh(m)
+    db.commit()
+    db.refresh(m)
     return m
 
 @router.delete("/{materia_id}")
@@ -100,9 +158,32 @@ def borrar_materia(
     _: Usuario = Depends(require_view("MATERIAS")),
 ):
     m = db.get(Materia, materia_id)
-    if not m: raise HTTPException(404, "Materia no encontrada")
-    db.delete(m); db.commit()
+    if not m:
+        raise HTTPException(404, "Materia no encontrada")
+
+    if m.estado == "INACTIVO":
+        return {"ok": True, "mensaje": "Materia ya estaba inactiva"}
+
+    m.estado = "INACTIVO"
+    db.commit()
+    db.refresh(m)
     return {"ok": True}
+
+
+@router.post("/{materia_id}/restore", response_model=MateriaOut)
+def restaurar_materia(
+    materia_id: int,
+    db: Session = Depends(get_db),
+    _: Usuario = Depends(require_view("MATERIAS")),
+):
+    materia = db.get(Materia, materia_id)
+    if not materia:
+        raise HTTPException(404, "Materia no encontrada")
+
+    materia.estado = "ACTIVO"
+    db.commit()
+    db.refresh(materia)
+    return materia
 
 @router.post("/__echo__")
 def echo(data: MateriaCreate):


### PR DESCRIPTION
## Summary
- default Materias listing to active records while allowing optional inclusion of inactive rows
- return HTTP 409 conflicts on duplicated codigo or nombre values and normalise estado payloads
- implement soft delete and restore workflow for materias instead of physical deletes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dea629ed3883259f440eb3e5d8f82e